### PR TITLE
Add community files and improve contributing guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug Report
+about: Something isn't working as expected
+labels: bug
+---
+
+**Plugin:** arn-spark / arn-code / arn-infra
+
+**Skill or agent:** (e.g., `/arn-spark-discover`, `arn-code-architect`)
+
+**What happened?**
+Describe the problem clearly.
+
+**What did you expect?**
+What should have happened instead.
+
+**Steps to reproduce:**
+1. Run `/skill-name`
+2. ...
+
+**Environment:**
+- OS: (e.g., macOS 15, Ubuntu 24.04, Windows 11 WSL2)
+- Claude Code version: (e.g., CLI 1.x, Desktop)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Help
+    url: https://github.com/AppsVortex/arness/discussions
+    about: Ask questions, get help, and discuss ideas in Discussions

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature Request
+about: Suggest a new skill, agent, or improvement
+labels: enhancement
+---
+
+**Plugin:** arn-spark / arn-code / arn-infra / new plugin
+
+**What would you like?**
+Describe the feature or improvement.
+
+**Use case:**
+What problem does this solve? When would you use it?
+
+**Alternatives considered:**
+Have you tried other approaches or workarounds?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Plugin affected
+
+- [ ] arn-spark
+- [ ] arn-code
+- [ ] arn-infra
+- [ ] Documentation only
+- [ ] Other
+
+## Checklist
+
+- [ ] Tested locally with `claude --plugin-dir plugins/<plugin>`
+- [ ] Version bumped in `plugin.json` (if applicable)
+- [ ] Version bumped in `marketplace.json` (if applicable)
+- [ ] Skill descriptions use "This skill should be used when..." pattern
+- [ ] Discrete user choices use `AskUserQuestion` convention
+- [ ] No absolute user paths in committed files

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainer at **fryderyk@appsvortex.com**. All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing to Arness
+
+Thanks for your interest in contributing! Arness is open source (MIT) and welcomes contributions of all kinds.
+
+## Quick Links
+
+- **Bug reports and feature requests:** [Open an issue](https://github.com/AppsVortex/arness/issues)
+- **Questions and discussions:** [Start a discussion](https://github.com/AppsVortex/arness/discussions)
+- **Full contributing guide:** [docs/contributing.md](docs/contributing.md) — covers plugin conventions, skill/agent structure, path rules, versioning, and local testing
+
+## Getting Started
+
+1. Fork and clone the repository
+2. Create a feature branch
+3. Make your changes following the [plugin conventions](docs/contributing.md)
+4. Test locally: `claude --plugin-dir plugins/arn-spark` (or `arn-code`, `arn-infra`)
+5. Bump the version in the affected plugin's `plugin.json` and `marketplace.json`
+6. Submit a PR with a clear description of what changed and why
+
+## Code of Conduct
+
+Please be respectful and constructive in all interactions. See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -9,6 +9,15 @@ sidebar:
 
 Arness is open source (MIT). Contributions are welcome — whether fixing a bug in a skill, adding a new agent, or improving documentation.
 
+## Before You Start
+
+- **Found a bug?** [Open an issue](https://github.com/AppsVortex/arness/issues) with the bug report template
+- **Have a question?** Start a thread in [Discussions](https://github.com/AppsVortex/arness/discussions) — issues are for bugs and feature requests
+- **Want a new feature?** [Open an issue](https://github.com/AppsVortex/arness/issues) with the feature request template, or discuss the idea first in Discussions
+- **Ready to contribute code?** Fork the repo, follow the conventions below, and submit a PR
+
+Please be respectful and constructive in all interactions. See our [Code of Conduct](../CODE_OF_CONDUCT.md).
+
 ## Repository Structure
 
 ```
@@ -49,13 +58,11 @@ plugins/<plugin>/skills/<skill-name>/SKILL.md
 ---
 name: "skill-name"
 description: "This skill should be used when... [trigger conditions]"
-version: "1.0.0"
 ---
 ```
 
 - **name**: The command name (invoked as `/skill-name`)
 - **description**: Must start with "This skill should be used when..." — this is how Claude Code matches user intent to skills
-- **version**: Semver, bumped with changes
 
 Supporting files (references, scripts, examples) go in the same subdirectory as the SKILL.md.
 
@@ -112,7 +119,7 @@ When creating a PR, bump the `version` in the affected plugin's `.claude-plugin/
 | New features, new skills/agents, significant behavior changes | Minor | 2.0.0 → 2.1.0 |
 | Breaking changes requiring re-init | Major | 2.1.0 → 3.0.0 |
 
-Include the version bump in the PR commit, not as a separate commit.
+Also update the version in `.claude-plugin/marketplace.json` to match. Include both version bumps in the PR commit, not as separate commits.
 
 ## Testing Locally
 
@@ -134,4 +141,5 @@ claude --plugin-dir plugins/arn-infra
 3. Make your changes
 4. Test locally with `claude --plugin-dir`
 5. Bump the version in the affected plugin's `plugin.json`
-6. Submit a PR with a clear description of what changed and why
+6. Update `marketplace.json` if you bumped a plugin version
+7. Submit a PR with a clear description of what changed and why


### PR DESCRIPTION
## Summary

- Add root `CONTRIBUTING.md` with quick-start links pointing to the full guide
- Add `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1)
- Add GitHub issue templates: bug report, feature request, and config to redirect questions to Discussions
- Add PR template with plugin checklist (testing, versioning, conventions)
- Improve `docs/contributing.md`: add "Before You Start" section, remove unsupported `version` from skill frontmatter, add `marketplace.json` to versioning instructions

## Plugin affected

- [ ] arn-spark
- [ ] arn-code
- [ ] arn-infra
- [x] Documentation only
- [x] Other

## Test plan

- [ ] Verify issue templates show when creating a new issue on the repo
- [ ] Verify PR template shows when opening a new PR
- [ ] Verify "Questions & Help" redirects to Discussions
- [ ] Read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` for accuracy