### PR TITLE
Fix batch-implement worktree isolation leaks (arn-code 3.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "arn-code",
       "source": "./plugins/arn-code",
       "description": "Core development pipeline for Claude Code — plan, implement, ship, review, and assess features with AI-assisted workflows. Progressive zero-config init with user profiling and expertise-aware recommendations. Three ceremony tiers (swift/standard/thorough) with severity-aware scope routing. Five entry points: arn-planning, arn-implementing, arn-shipping, arn-reviewing-pr, arn-assessing. Includes arn-code-sketch for UI preview, arn-code-swift for quick implementations, arn-code-standard for medium-complexity changes, and arn-code-catch-up for retroactive documentation.",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "author": {
         "name": "Fryderyk Benigni",
         "url": "https://github.com/fredcallagan"

--- a/plugins/arn-code/.claude-plugin/plugin.json
+++ b/plugins/arn-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "arn-code",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "repository": "https://github.com/AppsVortex/arness",
   "author": {
     "name": "Fryderyk Benigni",

--- a/plugins/arn-code/skills/arn-code-batch-implement/SKILL.md
+++ b/plugins/arn-code/skills/arn-code-batch-implement/SKILL.md
@@ -81,6 +81,8 @@ If file overlap detected between any features, show which features share files a
 
 Show estimated context: "[N] features will be implemented in parallel, each as an independent session."
 
+Inform the user about worktree location: "Workers run in pre-created worktrees at `.claude/worktrees/arn-batch-<slug>/` on branches `arn-batch/<slug>`. Worktrees are preserved until the corresponding PR is merged; `arn-code-batch-merge` cleans them up after each successful merge."
+
 ### Step 3: Launch Confirmation
 
 Ask (using `AskUserQuestion`):
@@ -94,26 +96,59 @@ Ask (using `AskUserQuestion`):
 - **Select subset** -- present a multi-select (using `AskUserQuestion` with `multiSelect: true`) listing all pending features by name. Proceed with selected features only.
 - **Cancel** -- exit.
 
-### Step 4: Spawn Workers
+### Step 4: Pre-create Worktrees and Spawn Workers
+
+The Agent tool's built-in `isolation: "worktree"` has known silent-failure modes (see upstream issues anthropics/claude-code#27881 and #39886) where concurrent spawns can skip worktree creation entirely and run agents directly in the main checkout. To eliminate this risk, the orchestrator pre-creates every worktree itself via `git worktree add`, then spawns agents **without** `isolation` and passes the absolute worktree path in the prompt.
 
 Read the worker instructions template from `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-batch-implement/references/worker-instructions.md`.
 
-For each feature to implement, spawn one Agent with:
-- `isolation: "worktree"`
-- `run_in_background: true`
+#### Step 4a: Compute Worktree Slugs
+
+For each selected feature, derive a slug from the feature name: lowercase, replace non-alphanumerics with `-`, collapse runs of `-`, trim leading/trailing `-`. Example: `Auth Service v2` → `auth-service-v2`.
+
+**Empty-slug fallback:** If sanitization produces an empty string (feature name was entirely non-alphanumeric, e.g., emojis or punctuation), substitute `feature-<index>` where `<index>` is the feature's 1-based position in the batch. This keeps provisioning deterministic instead of silently failing downstream.
+
+Capture the repo root once:
+
+```bash
+REPO="$(git rev-parse --show-toplevel)"
+```
+
+For each slug, resolve three possible collisions before provisioning — a path may already be taken, a branch may already exist from a prior run, and stale worktree metadata may block creation:
+
+1. **Path collision.** Check `git -C "$REPO" worktree list --porcelain` for an existing worktree at `$REPO/.claude/worktrees/arn-batch-<slug>`:
+   - None: path is free, proceed to the branch check.
+   - Exists on branch `arn-batch/<slug>` with clean status (`git -C "$REPO/.claude/worktrees/arn-batch-<slug>" status --porcelain` is empty): reuse it and mark this slug as "already provisioned" (skip Step 4b).
+   - Otherwise (dirty worktree, different branch, unknown state): append `-<n>` starting at `2` and re-check until the path is free.
+
+2. **Branch collision.** Once a path is free, check whether the target branch already exists: `git -C "$REPO" show-ref --verify --quiet "refs/heads/arn-batch/<slug>"`. If it does (common when a worktree was manually deleted but the branch wasn't cleaned up), `git worktree add -b` will fail. Keep incrementing `-<n>` on the slug until both path AND branch are free.
+
+#### Step 4b: Pre-create Worktrees Sequentially
+
+For each slug that needs creation (i.e., wasn't marked "already provisioned" in Step 4a), run:
+
+```bash
+git -C "$REPO" worktree add "$REPO/.claude/worktrees/arn-batch-<slug>" -b "arn-batch/<slug>"
+```
+
+Capture exit code and stderr per feature. Verify success by confirming the path appears in `git -C "$REPO" worktree list`. Split the feature list into:
+- `ready`: features with a valid worktree (newly created or reused).
+- `deferred`: features whose `git worktree add` failed. Store the stderr for the retry step.
+
+If **all** features land in `deferred`, report the errors and stop — something is broken globally (disk, permissions, corrupt `.git/worktrees/`). A retry loop cannot fix a systemic failure.
+
+#### Step 4c: Spawn Parallel Workers (ready set)
+
+For each feature in `ready`, spawn one Agent with:
+- **No** `isolation` parameter — worktrees already exist.
+- `run_in_background: true`.
 - A self-contained prompt built from the worker-instructions template, filled with:
-  - The feature's plan path (absolute)
-  - The detected tier (thorough, standard, or swift)
-  - The platform (`github`, `bitbucket`, or `none` — from `## Arness` config)
-  - Code patterns directory path (absolute)
-  - Template path (absolute)
-  - Sketch manifest path (absolute, if sketch exists; otherwise "none")
+  - `{worktree_path}`: the absolute path `$REPO/.claude/worktrees/arn-batch-<slug>`
+  - `{feature_name}`, `{plan_path}`, `{tier}`, `{platform}`, `{code_patterns_path}`, `{template_path}`, `{sketch_manifest_path}` as before.
 
-If a worker **fails to spawn** (Agent tool returns an error), report the failure, continue spawning remaining workers, and include the failed feature in the Step 5 summary with status "failed -- spawn error".
+**ALL agents in the ready set MUST be spawned in a SINGLE message** (multiple Agent tool calls in one response) so they run in parallel. Cap at **5 concurrent workers**. If `ready` has more than 5 entries, batch into groups of 5: launch group 1, wait for completion, launch group 2, etc.
 
-**ALL agents MUST be spawned in a SINGLE message** (multiple Agent tool calls in one response) so they run in parallel. Cap at **5 concurrent workers**.
-
-If more than 5 features are queued, batch into groups of 5. Launch the first group, wait for all workers in that group to complete, then launch the next group.
+If a worker's Agent call returns a spawn error, move that feature from `ready` to `deferred` with reason "spawn error: …". It will be retried sequentially in Step 6.
 
 ### Step 5: Track Progress
 
@@ -127,7 +162,7 @@ Present a status table as workers finish:
 | ...     | ...    | ...| ...      |
 ```
 
-Status values: "done", "failed -- <reason>"
+Status values: "done", "failed -- <reason>", "failed -- worktree provisioning (retry exhausted)" (set in Step 6 for features that couldn't get a worktree even after retry).
 
 If a worker fails: report the failure, continue tracking other workers, include the failed feature in the summary.
 
@@ -135,7 +170,24 @@ When all workers in the current batch complete, present the summary: **"[N/M] fe
 
 If there are additional batches (>5 features), launch the next batch and repeat.
 
-### Step 6: Handoff
+### Step 6: Retry Deferred Features (sequential)
+
+If the `deferred` set accumulated in Step 4 is empty, skip this step and go straight to handoff.
+
+Retry runs **after** the parallel workers from Step 4c finish, not alongside them — this avoids racing with live workers on `.git/worktrees/` metadata and keeps the orchestrator's output easy to read.
+
+For each feature in `deferred`, sequentially (one at a time, not in parallel):
+
+1. **Prune stale metadata:** `git -C "$REPO" worktree prune`. This clears entries for worktrees whose directories were removed but whose `.git/worktrees/` bookkeeping lingered — the single most common cause of transient `worktree add` failures.
+2. **Retry worktree creation:** re-run the Step 4b command. If the path or branch still collides, append `-retry` to the slug as a human-readable marker and try once more.
+3. **If creation succeeds:** spawn ONE foreground Agent (no `isolation`, no `run_in_background`) using the same worker-instructions prompt as Step 4c, with `{worktree_path}` set to the newly-created path. Wait for it to complete. Record its outcome in the Step 5 status table.
+4. **If creation still fails:** mark the feature as `failed -- worktree provisioning (retry exhausted)` in the status table and include the git error in the final summary.
+
+Do not retry more than once per feature. The goal is to recover from transient collisions and stale state, not to mask systemic failures.
+
+**Worked example.** Say the batch has three features: `auth-service`, `api-endpoints`, `settings-page`. Step 4b succeeds for the first two but `settings-page` fails because `.git/worktrees/arn-batch-settings-page/` holds stale metadata from a manually-deleted worktree. Step 4c spawns parallel workers for `auth-service` and `api-endpoints`; Step 5 tracks them to completion. Step 6 then: prunes the stale metadata, retries `git worktree add` for `settings-page` (now succeeds), spawns ONE foreground worker, waits, records "done" in the Step 5 table. Total outcome: 3/3 succeed — parallel workers were never blocked by the stuck feature.
+
+### Step 7: Handoff
 
 Ask (using `AskUserQuestion`):
 

--- a/plugins/arn-code/skills/arn-code-batch-implement/references/worker-instructions.md
+++ b/plugins/arn-code/skills/arn-code-batch-implement/references/worker-instructions.md
@@ -1,10 +1,11 @@
 # Arness Batch Worker: {feature_name}
 
-You are implementing a single feature as part of a batch implementation run. You are running in an isolated git worktree with full tool access. Work autonomously -- there is no user to interact with.
+You are implementing a single feature as part of a batch implementation run. You are running in a pre-created git worktree at `{worktree_path}`. Treat that path as the root of your universe: every file you read, write, or commit must live under it, and every git operation must target it explicitly via `git -C "$WORKTREE"`. Work autonomously -- there is no user to interact with.
 
 ## Your Assignment
 
 - **Feature:** {feature_name}
+- **Worktree path:** {worktree_path}
 - **Plan path:** {plan_path}
 - **Tier:** {tier}
 - **Platform:** {platform} (github, bitbucket, or none)
@@ -12,9 +13,32 @@ You are implementing a single feature as part of a batch implementation run. You
 - **Template path:** {template_path}
 - **Sketch manifest:** {sketch_manifest_path}
 
-**Branch name:** The worktree isolation creates a branch automatically. Discover your branch name with `git branch --show-current` and use it for push and PR operations.
-
 ## Execution Steps
+
+### 0. Anchor Your Worktree (MANDATORY FIRST STEP)
+
+Before any other work, run this Bash block exactly once and verify success. If any assertion fails, abort the worker by exiting non-zero — do NOT attempt to recover, do NOT proceed to Step 1.
+
+```bash
+WORKTREE="{worktree_path}"
+cd "$WORKTREE" || { echo "ISOLATION FAILURE: cannot cd to $WORKTREE"; exit 1; }
+
+ACTUAL="$(git -C "$WORKTREE" rev-parse --show-toplevel)"
+case "$ACTUAL" in
+  */.claude/worktrees/arn-batch-*) ;;
+  *) echo "ISOLATION FAILURE: $ACTUAL is not under .claude/worktrees/arn-batch-*. Aborting."; exit 1 ;;
+esac
+
+BRANCH="$(git -C "$WORKTREE" branch --show-current)"
+case "$BRANCH" in
+  main|master|"") echo "ISOLATION FAILURE: worktree is on branch '$BRANCH'. Aborting."; exit 1 ;;
+esac
+
+echo "WORKTREE=$WORKTREE"
+echo "BRANCH=$BRANCH"
+```
+
+`$WORKTREE` and `$BRANCH` are now anchored. Use them in every subsequent step. Every `git` call is `git -C "$WORKTREE" …` (never bare `git`). Every `Write` and `Edit` uses an absolute path starting with `$WORKTREE`. Do not use `cd` again for the rest of this session.
 
 ### 1. Read Pattern Documentation
 
@@ -119,7 +143,7 @@ Write the completed CHANGE_RECORD.json to the plan directory.
 
 ### 6. Commit
 
-Stage all implementation changes. Create a commit with the following message:
+Stage all implementation changes using absolute paths under `$WORKTREE` (e.g., `git -C "$WORKTREE" add "$WORKTREE/path/to/file"`, or `git -C "$WORKTREE" add -A` from within the worktree). Create a commit with the following message:
 
 ```
 [{tier}] Implement {feature_name}
@@ -130,20 +154,26 @@ Arness Artifacts:
 - Change Record: {change_record_path}
 ```
 
+Use `git -C "$WORKTREE" commit -m "…"`.
+
 ### 7. Push and Create PR
 
 Push the worktree branch to the remote:
 
 ```bash
-git push -u origin $(git branch --show-current)
+git -C "$WORKTREE" push -u origin "$BRANCH"
 ```
+
+If the push fails for any reason, report the git error in Step 8 and exit — do NOT attempt `--force` or `--force-with-lease` recovery.
 
 Create a PR based on the platform:
 
 **If {platform} is `github`:**
 
+`gh` infers the repo from the current directory, so run it inside a subshell scoped to `$WORKTREE`:
+
 ```bash
-gh pr create --title "[batch] {feature_name}" --body "$(cat <<'EOF'
+( cd "$WORKTREE" && gh pr create --title "[batch] {feature_name}" --body "$(cat <<'EOF'
 ## Summary
 
 Batch-implemented {feature_name} ({tier} tier).
@@ -154,17 +184,17 @@ Batch-implemented {feature_name} ({tier} tier).
 - **Plan:** {plan_path}
 - **Change Record:** {change_record_path}
 EOF
-)"
+)" )
 ```
 
 **If {platform} is `bitbucket`:**
 
 ```bash
-bkt pr create \
-  --title "[batch] {feature_name}" \
-  --description "<same body as above>" \
-  --source $(git branch --show-current) \
-  --destination main
+( cd "$WORKTREE" && bkt pr create \
+    --title "[batch] {feature_name}" \
+    --description "<same body as above>" \
+    --source "$BRANCH" \
+    --destination main )
 ```
 
 **If {platform} is `none`:**
@@ -172,11 +202,11 @@ bkt pr create \
 Skip PR creation. Report the branch name instead of a PR URL in Step 8.
 
 After PR creation, update `CHANGE_RECORD.json` with:
-- `commitHash`: the SHA from `git rev-parse HEAD`
+- `commitHash`: the SHA from `git -C "$WORKTREE" rev-parse HEAD`
 - `commitMessage`: the commit message used
 - `nextSteps`: include the PR URL (or branch name if no platform)
 
-Create a new commit with the updated CHANGE_RECORD.json and push. If the push fails, the PR from the initial push is still valid — report that PR URL in Step 8 regardless.
+Create a new commit with the updated CHANGE_RECORD.json and push via `git -C "$WORKTREE" push`. If the push fails, the PR from the initial push is still valid — report that PR URL in Step 8 regardless.
 
 ### 8. Report
 
@@ -194,8 +224,17 @@ Then the PR line:
 
 ## Rules
 
+### Worktree discipline
+
+Step 0 anchors `$WORKTREE` and states the core rules (no bare `git`, absolute paths, no `cd`). A few additional consequences are worth stating explicitly because they bite at points where the temptation to deviate is strongest:
+
+- **No force-push recovery.** If `git push` fails, report the git error in Step 8 and exit. `--force` / `--force-with-lease` can overwrite another worker's branch if a slug collision slipped past the orchestrator's checks — and the orchestrator can recover a failed push far better than you can.
+- **Sibling worktrees are off-limits.** Other `.claude/worktrees/arn-batch-*/` directories belong to parallel workers. Do not read, write, or run `git` against them — treat them as if they belong to a different user.
+- **Isolation failure is fatal.** If Step 0 aborts with `ISOLATION FAILURE`, exit immediately. Do not re-run Step 0, do not create your own worktree, do not continue on main. Your final report should include the isolation message and `PR: none -- isolation failure`.
+
+### Implementation discipline
+
 - Do NOT use AskUserQuestion -- you have no user interaction.
-- Do NOT modify files outside your worktree.
 - If tests fail 3 times on the same assertion, note the failure in your report and continue with the remaining work.
 - Follow all codebase patterns from the pattern documentation read in Step 1.
 - If {sketch_manifest_path} is not "none", ALWAYS promote from sketch rather than writing from scratch for matching files.

--- a/plugins/arn-code/skills/arn-code-batch-merge/SKILL.md
+++ b/plugins/arn-code/skills/arn-code-batch-merge/SKILL.md
@@ -153,7 +153,26 @@ Then update the local branch:
 git checkout main && git pull
 ```
 
-**If the merge fails** (CI checks, branch protection, conflicts): report the error: "Merge failed for [feature] (#PR): [error message]." Offer to skip and continue with another PR.
+**Clean up the feature's worktree (batch-implement worktrees only)**
+
+After the merge succeeds and `main` is up to date, remove the worktree and local branch created by `arn-code-batch-implement`. Only apply this cleanup when the merged PR's head branch starts with `arn-batch/` — other branches (manual work, hotfixes) are left alone.
+
+```bash
+HEAD_BRANCH="$(gh pr view <url> --json headRefName -q .headRefName)"   # or equivalent for bkt
+case "$HEAD_BRANCH" in
+  arn-batch/*)
+    SLUG="${HEAD_BRANCH#arn-batch/}"
+    REPO="$(git rev-parse --show-toplevel)"
+    WORKTREE_PATH="$REPO/.claude/worktrees/arn-batch-$SLUG"
+    git -C "$REPO" worktree remove --force "$WORKTREE_PATH" 2>/dev/null || true
+    git -C "$REPO" branch -D "$HEAD_BRANCH" 2>/dev/null || true
+    ;;
+esac
+```
+
+The `--force` flag is safe here: the branch's commits are already on `main`, so nothing is lost. Errors from both commands are ignored (the worktree or branch may have been cleaned up manually). Log the cleanup outcome alongside the PR URL in the merge summary: e.g. `✓ Merged #42 · worktree cleaned`.
+
+**If the merge fails** (CI checks, branch protection, conflicts): report the error: "Merge failed for [feature] (#PR): [error message]." Offer to skip and continue with another PR. Do NOT clean up the worktree — it still holds the only local copy of the work.
 
 If remaining open PRs > 0:
 - Re-run the `arn-code-batch-pr-analyzer` agent (foreground) with the updated PR list
@@ -188,6 +207,8 @@ Batch Merge Status: [N] merged, [M] still open
 | API endpoints | #43  | Merged  |
 | Settings page | #44  | Open    |
 ```
+
+**Unmerged worktree note:** Worktrees for unmerged features remain at `.claude/worktrees/arn-batch-<slug>/` on branches `arn-batch/<slug>`. They are preserved so the work is not lost. Once you decide what to do with each (rework, merge later, abandon), clean up manually with `git worktree remove <path>` and `git branch -D arn-batch/<slug>`, or re-run `arn-code-batch-merge` after resolving the blocker.
 
 ### Feature Tracker Update
 


### PR DESCRIPTION
## Background

Field report from a silmaril batch run (`arn-code@3.2.0`) — two parallel batches, 5 and 4 workers, both leaked writes into the main checkout despite `isolation: "worktree"` being set on every spawn. In the worst case a worker was killed mid-push by a safety-policy flag and its worktree directory was cleaned up before commits could be recovered.

Two root causes:

1. **The Agent tool's `isolation: "worktree"` fails silently under concurrent spawns** (upstream anthropics/claude-code#27881, #39886) — for Run 1, only 1 of 5 workers got a worktree at all; the other 4 ran directly in the main checkout.
2. **Even when worktrees are created, subprocess cwd drifts** away from the worktree path across Bash tool calls, so relative-path writes (git add paths, `gh pr create`, `npm install`) can hit the shared main checkout.

## Summary

- **Orchestrator pre-creates every worktree** via `git worktree add` before spawning any agent, then spawns agents without `isolation` and passes the absolute worktree path into the prompt. Eliminates reliance on the silently-failing built-in isolation.
- **Workers anchor `\$WORKTREE` in a mandatory Step 0** before any other work, fail-closed on isolation assertion errors (not under `.claude/worktrees/arn-batch-*`, on `main`/`master`, or unresolvable path).
- **Worktree discipline:** every `git` call is `git -C "\$WORKTREE"`, every `Write`/`Edit` uses an absolute path under `\$WORKTREE`, no `cd` outside Step 0, no force-push recovery.
- **Sequential retry path** for features whose worktree provisioning fails transiently (most commonly stale `.git/worktrees/` metadata from a manually-deleted worktree) — runs after parallel workers finish so there's no contention on `.git/worktrees/`.
- **Slug resolution handles path AND branch collisions** plus an empty-slug fallback (`feature-<index>`).
- **`arn-code-batch-merge` cleans up worktrees** after each successful merge; unmerged worktrees are preserved and surfaced in the final report.

## Changes

- `plugins/arn-code/skills/arn-code-batch-implement/SKILL.md` — Step 4 restructured (4a compute slugs → 4b pre-create → 4c spawn parallel), Step 6 sequential retry, Step 7 handoff.
- `plugins/arn-code/skills/arn-code-batch-implement/references/worker-instructions.md` — mandatory Step 0 anchor + ISOLATION FAILURE gate, `git -C` discipline, absolute-path rule, tightened Rules section.
- `plugins/arn-code/skills/arn-code-batch-merge/SKILL.md` — worktree cleanup after merge, unmerged-worktree preservation notice.
- `arn-code` version bumped 3.2.0 → 3.3.0 (plugin + marketplace).

## Test plan

- [x] Run `/arn-code-batch-implement` with 3+ features; confirm every worker's commits land on its own branch and no files appear in the main checkout.
- [x] Force a transient `worktree add` failure (e.g., pre-create a stale `.git/worktrees/arn-batch-<slug>/` dir) and confirm Step 6 prunes and retries successfully.
- [x] Run `/arn-code-batch-merge` against the resulting PRs; confirm worktrees under `.claude/worktrees/arn-batch-*/` are removed after each successful merge and preserved for unmerged features.
- [x] Verify a worker that starts with a bad worktree path reports `PR: none -- isolation failure` rather than leaking writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)