### PR TITLE
Add Star History chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,15 @@ Then run the entry point that matches what you want to do — Arness auto-config
 
 Created by [Fryderyk Benigni](https://github.com/fredcallagan) at [AppsVortex](https://github.com/AppsVortex).
 
+## Star History
+
+<a href="https://star-history.com/#AppsVortex/arness&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=AppsVortex/arness&type=Date&theme=dark" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=AppsVortex/arness&type=Date" />
+  </picture>
+</a>
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

- Adds a `## Star History` section between `## Built with Arness` and `## License` in the main README.
- Uses star-history.com with a `<picture>` tag so the chart renders correctly in both GitHub light and dark themes.
- Anchor-wraps the chart to the live star-history.com comparison page, so visitors can pivot into comparison mode (useful later for milestone comparisons against competitor repos).

## Rationale

- **Placement before License** is the de facto convention for modern OSS READMEs (shadcn/ui, Vercel, Supabase) — social proof after the maker signoff, legal footer last.
- **`<picture>` tag with a dark `<source>` + `<img>` fallback** — GitHub has supported this since 2022. Without it, the default light-theme SVG looks washed out on GitHub's dark UI. The explicit light `<source>` is redundant with the `<img>` fallback, so it's omitted for a tighter diff.
- **`&type=Date`** shows stars-over-time, the right chart for a launch-phase repo.

## Test plan

- [ ] GitHub renders the chart in light theme (cleared browser theme or light account preference)
- [ ] GitHub renders the chart in dark theme (dark account preference) — colors legible, no washed-out white background
- [ ] Clicking the chart opens `https://star-history.com/#AppsVortex/arness&Date`
- [ ] `## Star History` appears in GitHub's auto-generated TOC in the right rail

🤖 Generated with [Claude Code](https://claude.com/claude-code)