### PR TITLE
chore(marketplace): fix validation errors, add metadata.description

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,14 +1,12 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "arn-marketplace",
   "owner": {
     "name": "AppsVortex"
   },
-  "author": {
-    "name": "Fryderyk Benigni",
-    "url": "https://github.com/fredcallagan"
+  "metadata": {
+    "description": "Three plugins for Claude Code — Spark (greenfield discovery), Code (development pipeline), Infra (infrastructure and deployment). Each stage produces durable Markdown/JSON artifacts the next consumes. MIT, local-only.",
+    "version": "1.0.0"
   },
-  "license": "MIT",
   "plugins": [
     {
       "name": "arn-code",


### PR DESCRIPTION
## Summary

Unblocks `claude plugin validate .` (currently failing) and prepares the marketplace for third-party listing sites like claudemarketplaces.com that silently skip manifests which fail validation.

## What changed

- **Removed** three root-level keys that are not in the official [marketplace schema](https://code.claude.com/docs/en/plugin-marketplaces#required-fields) and were explicitly rejected by the validator (`root: Unrecognized keys: "\$schema", "author", "license"`):
  - `\$schema` — a JSON convention, but not accepted by this schema.
  - `author` (root-level) — maintainer identity at the marketplace level is carried by `owner`. Per-plugin `author` blocks (which are explicitly valid per the docs) remain untouched.
  - `license` — license info lives in the repo `LICENSE` file and README, not the marketplace manifest.
- **Added** a `metadata` block with `description` and `version`. The validator emits a non-blocking warning when `metadata.description` is missing, and third-party crawlers rely on it to render a populated card.
- **Preserved** everything else: all three plugin entries, per-plugin `description` / `version` / `author` / `source` / `category` are byte-identical. `arn-infra.category` stays `"infrastructure"` — the docs describe `category` as free-form ("Plugin category for organization") with no enum or allowlist, so the semantically correct value is kept.

## Before / after

```
✘ Found 1 error:
  ❯ root: Unrecognized keys: "\$schema", "author", "license"
✘ Validation failed
```

after:

```
✔ Validation passed
```

## Test plan

- [x] `claude plugin validate .` reports "Validation passed" with zero errors and zero warnings
- [x] `python3 -m json.tool` parses the file cleanly (no syntax errors)
- [x] `git diff --stat` shows only `marketplace.json` changed (3 insertions, 5 deletions)
- [ ] After merge, confirm claudemarketplaces.com picks up the listing on its next crawl cycle

## References

- [Plugin marketplace schema](https://code.claude.com/docs/en/plugin-marketplaces#marketplace-schema) — authoritative source for valid root keys
- [Optional metadata fields](https://code.claude.com/docs/en/plugin-marketplaces#optional-metadata) — confirms `metadata.description`, `metadata.version`, `metadata.pluginRoot` as the accepted sub-keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)