### PR TITLE
fix(plugins): add marketplace add step to per-plugin install blocks

### DIFF
--- a/plugins/arn-code/README.md
+++ b/plugins/arn-code/README.md
@@ -5,6 +5,10 @@ Structured, artifact-driven development pipeline for Claude Code. Every feature 
 ## Install
 
 ```
+# Add the Arness marketplace (one-time)
+/plugin marketplace add AppsVortex/arness
+
+# Install this plugin
 /plugin install arn-code@arn-marketplace
 ```
 

--- a/plugins/arn-infra/README.md
+++ b/plugins/arn-infra/README.md
@@ -7,6 +7,10 @@ Infrastructure and deployment plugin for Claude Code. Audits your toolchain, gen
 ## Install
 
 ```
+# Add the Arness marketplace (one-time)
+/plugin marketplace add AppsVortex/arness
+
+# Install this plugin
 /plugin install arn-infra@arn-marketplace
 ```
 

--- a/plugins/arn-spark/README.md
+++ b/plugins/arn-spark/README.md
@@ -5,6 +5,10 @@ Greenfield exploration plugin for Claude Code. Takes a raw idea through product 
 ## Install
 
 ```
+# Add the Arness marketplace (one-time)
+/plugin marketplace add AppsVortex/arness
+
+# Install this plugin
 /plugin install arn-spark@arn-marketplace
 ```
 


### PR DESCRIPTION
## Summary

The per-plugin READMEs added in #19 show only `/plugin install <name>@arn-marketplace` in their install block, which fails for any user who hasn't already added the Arness marketplace. This is a real problem for users who land on a plugin subdirectory in isolation — e.g. via a plugin directory card that links straight to `plugins/arn-code/` — because there's no indication that the marketplace needs to be registered first.

This PR updates the install block in all three per-plugin READMEs to match the pattern used in the root README and `docs/getting-started.md`: a one-time `/plugin marketplace add AppsVortex/arness`, then the per-plugin install. Kept as a single fenced code block to match the root README's style.

## Changes

- `plugins/arn-code/README.md` — install block now shows both steps
- `plugins/arn-spark/README.md` — install block now shows both steps
- `plugins/arn-infra/README.md` — install block now shows both steps

Cherry-pick of `8b503b9` onto a fresh branch off `main`. The original commit landed on the branch for #19 after that PR had already merged, so it never reached `main`.

## Test plan

- [x] `git diff --stat main` shows only the 3 README files changed (12 insertions, 0 deletions)
- [ ] Manual smoke test: reader landing on `plugins/arn-code/README.md` can follow the install block verbatim in a fresh Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)