### PR TITLE
chore(plugins): drop version from plugin.json for relative-path plugins

### DIFF
--- a/plugins/arn-code/.claude-plugin/plugin.json
+++ b/plugins/arn-code/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "arn-code",
-  "version": "3.3.0",
   "repository": "https://github.com/AppsVortex/arness",
   "author": {
     "name": "Fryderyk Benigni",

--- a/plugins/arn-infra/.claude-plugin/plugin.json
+++ b/plugins/arn-infra/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "arn-infra",
-  "version": "2.2.0",
   "repository": "https://github.com/AppsVortex/arness",
   "author": {
     "name": "Fryderyk Benigni",

--- a/plugins/arn-spark/.claude-plugin/plugin.json
+++ b/plugins/arn-spark/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "arn-spark",
-  "version": "2.2.0",
   "repository": "https://github.com/AppsVortex/arness",
   "author": {
     "name": "Fryderyk Benigni",


### PR DESCRIPTION
## Summary

Removes the redundant `version` field from each plugin's `plugin.json`, making `marketplace.json` the single source of truth for plugin versions.

## Rationale

The [Claude Code plugin docs](https://code.claude.com/docs/en/plugins-reference#version-management) flag a subtle gotcha:

> When possible, avoid setting the version in both places. The plugin manifest always wins silently, which can cause the marketplace version to be ignored. For relative-path plugins, set the version in the marketplace entry. For all other plugin sources, set it in the plugin manifest.

All three Arness plugins use relative-path sources (`./plugins/arn-code`, etc.), so per the docs the version should live in `marketplace.json` only.

## State before / after

Versions currently agree, so this is a purely structural change — no user-visible behavior difference. It just removes the latent drift risk at the next version bump: if a future PR updates one place and forgets the other, the plugin manifest would silently win and the marketplace-declared version would be ignored.

| Plugin | Version (unchanged) | Location before | Location after |
|---|---|---|---|
| arn-code | 3.3.0 | both | `marketplace.json` only |
| arn-spark | 2.2.0 | both | `marketplace.json` only |
| arn-infra | 2.2.0 | both | `marketplace.json` only |

## Test plan

- [x] All three `plugin.json` files parse as valid JSON (`python3 -m json.tool`)
- [x] `claude plugin validate .` reports "Validation passed" with zero errors and zero warnings
- [x] `git diff --stat` shows exactly 3 deletions — one `version` key per plugin.json
- [x] `marketplace.json` unchanged; plugin-level `name`, `repository`, `author`, `description` all preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)