### PR TITLE
feat: agent model config + complex-phase upgrade + ensure-config cache

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "arn-code",
       "source": "./plugins/arn-code",
       "description": "Core development pipeline for Claude Code — plan, implement, ship, review, and assess features with AI-assisted workflows. Progressive zero-config init with user profiling and expertise-aware recommendations. Three ceremony tiers (swift/standard/thorough) with severity-aware scope routing. Five entry points: arn-planning, arn-implementing, arn-shipping, arn-reviewing-pr, arn-assessing. Includes arn-code-sketch for UI preview, arn-code-swift for quick implementations, arn-code-standard for medium-complexity changes, and arn-code-catch-up for retroactive documentation.",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "author": {
         "name": "Fryderyk Benigni",
         "url": "https://github.com/fredcallagan"
@@ -23,7 +23,7 @@
       "name": "arn-spark",
       "source": "./plugins/arn-spark",
       "description": "Greenfield project exploration — product discovery with AI-assisted persona generation and competitive landscape research, brand naming through structured 4-step methodology with domain and trademark screening, architecture vision, use case authoring, project scaffolding, visual style exploration, static and interactive prototype validation, prototype preservation, feature extraction, visual testing strategy, stress testing suite, concept review, and issue tracker integration. Progressive zero-config init with user profiling and expertise-aware recommendations. Can operate standalone or alongside the arn-code core plugin.",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "author": {
         "name": "Fryderyk Benigni",
         "url": "https://github.com/fredcallagan"
@@ -34,7 +34,7 @@
       "name": "arn-infra",
       "source": "./plugins/arn-infra",
       "description": "Infrastructure and deployment — containerization, IaC generation, deployment, CI/CD pipelines, environment management, secrets, monitoring, migration, and structured change management. Progressive zero-config init with user profiling and expertise-aware recommendations. Can operate standalone or alongside the arn-code core plugin.",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "author": {
         "name": "Fryderyk Benigni",
         "url": "https://github.com/fredcallagan"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "arn-code",
       "source": "./plugins/arn-code",
       "description": "Core development pipeline for Claude Code — plan, implement, ship, review, and assess features with AI-assisted workflows. Progressive zero-config init with user profiling and expertise-aware recommendations. Three ceremony tiers (swift/standard/thorough) with severity-aware scope routing. Five entry points: arn-planning, arn-implementing, arn-shipping, arn-reviewing-pr, arn-assessing. Includes arn-code-sketch for UI preview, arn-code-swift for quick implementations, arn-code-standard for medium-complexity changes, and arn-code-catch-up for retroactive documentation.",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "author": {
         "name": "Fryderyk Benigni",
         "url": "https://github.com/fredcallagan"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "arn-code",
       "source": "./plugins/arn-code",
       "description": "Core development pipeline for Claude Code — plan, implement, ship, review, and assess features with AI-assisted workflows. Progressive zero-config init with user profiling and expertise-aware recommendations. Three ceremony tiers (swift/standard/thorough) with severity-aware scope routing. Five entry points: arn-planning, arn-implementing, arn-shipping, arn-reviewing-pr, arn-assessing. Includes arn-code-sketch for UI preview, arn-code-swift for quick implementations, arn-code-standard for medium-complexity changes, and arn-code-catch-up for retroactive documentation.",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "author": {
         "name": "Fryderyk Benigni",
         "url": "https://github.com/fredcallagan"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "arn-code",
       "source": "./plugins/arn-code",
       "description": "Core development pipeline for Claude Code — plan, implement, ship, review, and assess features with AI-assisted workflows. Progressive zero-config init with user profiling and expertise-aware recommendations. Three ceremony tiers (swift/standard/thorough) with severity-aware scope routing. Five entry points: arn-planning, arn-implementing, arn-shipping, arn-reviewing-pr, arn-assessing. Includes arn-code-sketch for UI preview, arn-code-swift for quick implementations, arn-code-standard for medium-complexity changes, and arn-code-catch-up for retroactive documentation.",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "author": {
         "name": "Fryderyk Benigni",
         "url": "https://github.com/fredcallagan"
@@ -23,7 +23,7 @@
       "name": "arn-spark",
       "source": "./plugins/arn-spark",
       "description": "Greenfield project exploration — product discovery with AI-assisted persona generation and competitive landscape research, brand naming through structured 4-step methodology with domain and trademark screening, architecture vision, use case authoring, project scaffolding, visual style exploration, static and interactive prototype validation, prototype preservation, feature extraction, visual testing strategy, stress testing suite, concept review, and issue tracker integration. Progressive zero-config init with user profiling and expertise-aware recommendations. Can operate standalone or alongside the arn-code core plugin.",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "author": {
         "name": "Fryderyk Benigni",
         "url": "https://github.com/fredcallagan"
@@ -34,7 +34,7 @@
       "name": "arn-infra",
       "source": "./plugins/arn-infra",
       "description": "Infrastructure and deployment — containerization, IaC generation, deployment, CI/CD pipelines, environment management, secrets, monitoring, migration, and structured change management. Progressive zero-config init with user profiling and expertise-aware recommendations. Can operate standalone or alongside the arn-code core plugin.",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "author": {
         "name": "Fryderyk Benigni",
         "url": "https://github.com/fredcallagan"

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Force LF line endings on shell scripts so Windows checkouts (where Git's
+# autocrlf=true is the default) don't corrupt the bash shebang or break
+# `chmod +x` semantics. Required for the ensure-config cache-check.sh
+# scripts that run on user machines.
+plugins/*/skills/*-ensure-config/scripts/*.sh text eol=lf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,8 @@ When updating default report templates in `plugins/arn-code/skills/arn-code-save
 
 Checksums are generated at init-time by Claude (via `sha256sum` or `shasum -a 256`), not pre-computed in the repository.
 
+Agent model profile files (`.arness/agent-models/<plugin>.md`) follow the same versioning and update policy as report templates: each preset carries a `# Version:` header, ensure-config detects version drift on each invocation, and the project's `Template updates: ask | auto | manual` setting controls update behavior. User edits to the file (detected via checksum mismatch) auto-flip the corresponding `## Arness` profile field to `custom` so future preset updates do not overwrite user customizations. See "Agent Model Profiles" below for the field-level behavior.
+
 ## Plugin Component Conventions
 
 ### Skills (preferred for new functionality)
@@ -51,6 +53,16 @@ Checksums are generated at init-time by Claude (via `sha256sum` or `shasum -a 25
 ### Agents
 - Files: `plugins/<plugin>/agents/<agent-name>.md`
 - Frontmatter: `name`, `description` (with `<example>` blocks for triggers), `tools`, `model`, `color`
+
+### When adding a new agent
+
+Every new agent must be wired into both model profile presets so that users on either preset get a defined model assignment. Steps:
+
+1. Create the agent file at `plugins/<plugin>/agents/<agent-name>.md` with frontmatter (`model: opus`).
+2. Add the agent to BOTH `all-opus.md` and `balanced.md` presets in `plugins/<plugin>/skills/<plugin>-init/references/agent-models-presets/`. Decide the tier in `balanced` per the existing tiering principles (heavy reasoning → `opus`, operational/structured work → `sonnet`).
+3. Bump each preset's `# Version:` header (e.g., `1.0.0` → `1.1.0`).
+4. Bump the plugin version in the marketplace entry per the existing semver rules in the "Versioning" section below.
+5. If the new agent is invoked from any skill, that dispatch site must include the model lookup per the "Dispatch convention" in `plugins/<plugin>/skills/<plugin>-ensure-config/references/ensure-config.md`.
 
 ### User Interaction Convention
 - All discrete user choices (numbered options, yes/no decisions, multi-select menus) MUST use `Ask (using \`AskUserQuestion\`):` followed by the bold question text and numbered options
@@ -85,6 +97,26 @@ Each project's `## Arness` block carries a `Linting:` field with one of three va
 When the field is missing, `arn-code-ensure-config` (Layer 2c) prompts the user with the same 3-option menu and, if `enabled` is chosen, invokes the codebase analyzer to generate `linting.md`.
 
 The analyzer is technology-agnostic: it does not pattern-match against a fixed list of tool names. Instead it scans evidence categories (dependency manifests, tool config files, script entry points, pre-commit-style runners) and recognizes whatever tooling the project actually uses. Linters and formatters are listed separately in `linting.md` because they have different semantics — formatters typically have both a check mode and a write mode, and the gate must invoke the check mode (`Discovered check command`) so files are never silently rewritten.
+
+## Agent Model Profiles
+
+Each plugin's subagents can run under a user-selectable model profile, letting cost-sensitive users opt out of all-Opus invocation without forking the plugin. The choice is per-plugin and editable.
+
+Each project's `## Arness` block carries one field per installed plugin:
+
+- **Code agent model profile:** `all-opus | balanced | custom`
+- **Spark agent model profile:** `all-opus | balanced | custom`
+- **Infra agent model profile:** `all-opus | balanced | custom`
+
+Semantics:
+
+- **`all-opus`** — every subagent runs on Opus. Default for new projects; preserves current behavior.
+- **`balanced`** — Opus for heavy reasoning agents (planners, architects, reviewers); Sonnet for operational/structured agents (executors, scaffolders, dispatch helpers). Per-agent assignments live in `.arness/agent-models/<plugin>.md`.
+- **`custom`** — the project's `.arness/agent-models/<plugin>.md` has been hand-edited. Set automatically when ensure-config detects a checksum mismatch against the named preset; future preset updates skip the file so customizations are preserved.
+
+The three fields are independent — only the plugins a user has installed need a corresponding field. Default is `all-opus`. The active per-agent model assignments live in `.arness/agent-models/<plugin>.md`, copied at init-time from `plugins/<plugin>/skills/<plugin>-init/references/agent-models-presets/<choice>.md`. Each dispatch site reads this file and passes the resolved model as the Task tool's `model:` parameter, overriding the agent's frontmatter.
+
+Updates flow through the same checksum + version + `Template updates: ask | auto | manual` policy as report templates (see "Template Management" above). When a plugin ships a new preset version, ensure-config compares the project's stored version against the plugin version and either auto-updates, prompts, or skips per the user's policy. Hand-editing `.arness/agent-models/<plugin>.md` flips the corresponding profile field to `custom` so subsequent preset bumps do not clobber the edits.
 
 ## Testing Locally as a Plugin
 

--- a/plugins/arn-code/agents/arn-code-feature-planner.md
+++ b/plugins/arn-code/agents/arn-code-feature-planner.md
@@ -100,10 +100,35 @@ Group the work into logical phases. Each phase should produce a **testable incre
 
 **For each phase, define:**
 - Phase name and objective (1-2 sentences)
+- **Complexity rating** (`simple`, `moderate`, or `complex`) — see "Complexity Assessment per Phase" below
+- **Complexity rationale** (1 line) — the load-bearing reason for the rating
 - Deliverables: specific files to create or modify, with descriptions
 - Tasks: concrete implementation steps with file paths and pattern references
 - Dependencies: which earlier phases must be complete before this one starts
 - Testing approach: what tests to write and run for this phase (if applicable)
+
+#### Complexity Assessment per Phase
+
+Rate each phase against the 6 criteria from `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-swift/references/complexity-criteria.md`:
+
+1. **File count** — simple: 1-3 files; moderate: 4-8; complex: 9+
+2. **Architectural changes** — simple: none; moderate: minor extensions; complex: new abstractions or patterns
+3. **Cross-cutting concerns** — simple: single module; moderate: 2-3 modules; complex: 4+ modules / system-wide
+4. **Test work** — simple: 1-3 updates; moderate: 4-8; complex: new test infrastructure
+5. **UI scope** — simple: no UI or minor tweak; moderate: new component or significant modification; complex: new page or flow
+6. **Risk level** — simple: easily reversible; moderate: medium-risk modifications; complex: data migrations / breaking changes / auth/payment changes
+
+**Phase rating rules** (apply to the phase's combined criterion ratings):
+- `simple` — 5-6 criteria rate simple AND no architectural risk
+- `moderate` — 3-4 criteria rate simple, OR isolated complex criterion with rest simple/moderate
+- `complex` — 3+ criteria rate complex, OR a fundamental architectural risk in this phase
+
+**Complexity rationale** is a 1-line summary of the load-bearing reason — the criterion or risk that drove the rating. Examples:
+- `complex` → "12 files across 4 modules; new abstraction layer for repository pattern"
+- `moderate` → "5 files in 2 modules; extends existing event-handler pattern with one new variant"
+- `simple` → "2 files in single module; adds test for existing utility"
+
+The `arn-code-plan` skill consumes the per-phase complexity to surface it in the plan summary and, if `complex` AND the user's profile is not `all-opus`, to gate an executor model upgrade per `pipeline.complex-phase-upgrade` (see `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/preferences-schema.md`). Be honest in your ratings — under-rating cheats the user out of the upgrade offer; over-rating creates unnecessary cost.
 
 ### 4. Write the Plan
 
@@ -141,6 +166,9 @@ Spec: <specs-dir>/<spec-filename>
 ## Phase 1: [Phase Name]
 
 **Objective:** [1-2 sentences]
+
+**Complexity:** simple | moderate | complex
+**Complexity rationale:** [1 line — the load-bearing reason for the rating, e.g., "9 files across 3 modules; new repository abstraction"]
 
 **Dependencies:** None | Phase N
 

--- a/plugins/arn-code/skills/arn-assessing/SKILL.md
+++ b/plugins/arn-code/skills/arn-assessing/SKILL.md
@@ -21,7 +21,7 @@ This skill is a **medium orchestration wrapper**. It MUST NOT duplicate `arn-cod
 
 ## Step 0: Ensure Configuration
 
-Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/ensure-config.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/step-0-fast-path.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
 
 After Step 0 completes, extract the following from `## Arness`:
 - **Code patterns** — path to the directory containing stored pattern documentation

--- a/plugins/arn-code/skills/arn-code-assess/SKILL.md
+++ b/plugins/arn-code/skills/arn-code-assess/SKILL.md
@@ -124,17 +124,17 @@ Read ${CLAUDE_PLUGIN_ROOT}/skills/arn-code-assess/references/assessment-protocol
 
 **Agent invocations — launch all applicable agents in parallel:**
 
-**Always invoke `arn-code-architect`** with:
+**Always invoke the `arn-code-architect` agent** via the Task tool, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - The architect assessment prompt template from the protocol
 - Codebase context: full content of `code-patterns.md`, `testing-patterns.md`, `architecture.md`
 - Scope: the scope from G1
 
-**If `has_ui_patterns` is true**, also invoke `arn-code-ux-specialist` with:
+**If `has_ui_patterns` is true**, also invoke the `arn-code-ux-specialist` agent via the Task tool, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - The UX specialist assessment prompt template from the protocol
 - Context: `ui-patterns.md`, `architecture.md`, `code-patterns.md`
 - Scope from G1
 
-**If `has_security_patterns` is true**, also invoke `arn-code-security-specialist` with:
+**If `has_security_patterns` is true**, also invoke the `arn-code-security-specialist` agent via the Task tool, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - The security specialist assessment prompt template from the protocol
 - Context: `security-patterns.md`, `architecture.md`, `code-patterns.md`
 - Scope from G1
@@ -303,7 +303,7 @@ Show progress:
 Arness Assess: scope → assess → prioritize → spec(s) → plan → save → execute → TEST → ship                                                                                ^^^^
 ```
 
-Invoke the `arn-code-test-specialist` agent via the Agent tool with:
+Invoke the `arn-code-test-specialist` agent via the Agent tool, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - **Scope:** "full suite"
 - **Code patterns directory:** the configured code-patterns path
 

--- a/plugins/arn-code/skills/arn-code-batch-implement/SKILL.md
+++ b/plugins/arn-code/skills/arn-code-batch-implement/SKILL.md
@@ -26,7 +26,7 @@ arn-code-batch-planning -> **arn-code-batch-implement** (pre-flight -> spawn wor
 
 ### Step 0: Ensure Configuration
 
-Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/ensure-config.md` and follow its instructions. Extract from `## Arness`:
+Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/step-0-fast-path.md` and follow its instructions. Extract from `## Arness`:
 
 - **Plans directory** -- base path where project plans are saved
 - **Code patterns** -- path to the directory containing stored pattern documentation

--- a/plugins/arn-code/skills/arn-code-batch-implement/references/worker-instructions.md
+++ b/plugins/arn-code/skills/arn-code-batch-implement/references/worker-instructions.md
@@ -68,7 +68,12 @@ Follow the same executor → reviewer → fix cycle as `arn-code-execute-plan`'s
    Always promote from sketch rather than writing matching files from scratch.
 4. **Execute-review cycle per task** (respecting dependency order from TASKS.md):
 
-   a. **Spawn executor**: Spawn a `arn-code-task-executor` agent with:
+   a. **Spawn executor**: First **determine the executor model**:
+      - Read PROGRESS_TRACKER.json. Find the phase entry whose `implementation.taskId` matches the current task ID.
+      - If `phase.implementation.modelOverride` is non-null (e.g., `"opus"`), use that value as the `model` parameter for this dispatch. Skip the standard agent-models lookup. Emit a one-line status: `Phase <N> (<phaseTitle>) executor model: <override> (upgraded — complex phase per pipeline.complex-phase-upgrade)`.
+      - If `phase.implementation.modelOverride` is null or the field is missing, fall through to the standard lookup: pass the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback).
+
+      Then spawn a `arn-code-task-executor` agent via the Task tool with the determined model. Context:
       - The task ID and full task description (from TASKS.md)
       - Project folder path: {plan_path}
       - Phase plan file path (extracted from the task description)
@@ -78,7 +83,7 @@ Follow the same executor → reviewer → fix cycle as `arn-code-execute-plan`'s
       - Sketch context (manifest path and directory, if applicable)
       - Instructions: implement the task according to the phase plan, run ONLY targeted tests (precise targeting, never full suite), generate IMPLEMENTATION_REPORT and/or TESTING_REPORT
 
-   b. **Spawn reviewer**: After executor completes, spawn a `arn-code-task-reviewer` agent with:
+   b. **Spawn reviewer**: After executor completes, spawn a `arn-code-task-reviewer` agent via the Task tool, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
       - The task ID and description
       - Implementation/testing report paths from the executor
       - List of files created/modified by the executor

--- a/plugins/arn-code/skills/arn-code-batch-merge/SKILL.md
+++ b/plugins/arn-code/skills/arn-code-batch-merge/SKILL.md
@@ -29,7 +29,7 @@ arn-code-batch-implement -> **arn-code-batch-merge** -> arn-code-batch-simplify
 
 ## Step 0: Ensure Configuration
 
-Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/ensure-config.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/step-0-fast-path.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
 
 After configuration is ensured, extract the following from `## Arness`:
 - **Plans directory** -- base path where project plans and CHANGE_RECORD.json files are stored
@@ -80,7 +80,7 @@ Collect the final list: PR number, URL, feature name, CHANGE_RECORD path, platfo
 
 ## Step 2: Cross-PR Analysis (Delegated)
 
-Spawn the `arn-code-batch-pr-analyzer` agent in **foreground** (the results are needed before proceeding).
+Spawn the `arn-code-batch-pr-analyzer` agent via the Task tool in **foreground** (the results are needed before proceeding), passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback).
 
 Pass to the agent:
 - PR list (number, URL, feature name, CHANGE_RECORD path)

--- a/plugins/arn-code/skills/arn-code-batch-planning/SKILL.md
+++ b/plugins/arn-code/skills/arn-code-batch-planning/SKILL.md
@@ -45,7 +45,7 @@ Sources:
 
 ## Step 0: Ensure Configuration
 
-Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/ensure-config.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/step-0-fast-path.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
 
 After configuration is ensured, extract the following from `## Arness`:
 - **Plans directory** — base path where project plans and PLAN_PREVIEW files are stored
@@ -331,7 +331,7 @@ Pre-analyzing [K] thorough features in parallel...
 (Swift and standard features already have plans — skipping pre-analysis for those.)
 ```
 
-For each thorough feature, spawn a `arn-code-batch-analyzer` agent with:
+For each thorough feature, spawn a `arn-code-batch-analyzer` agent via the Task tool, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - `run_in_background: true`
 - The feature's input type and source-specific context:
   - Greenfield: feature ID, feature file path, vision dir, use cases dir
@@ -416,7 +416,7 @@ After feature-spec completes and the finalized spec file exists (FEATURE_*.md):
 
 1. Read the finalized spec file
 2. Derive the spec name from the filename
-3. Spawn the `arn-code-feature-planner` agent with:
+3. Spawn the `arn-code-feature-planner` agent via the Task tool, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
    - `run_in_background: true`
    - The full spec file content (FEATURE_*.md or BUGFIX_*.md)
    - The spec file path (for the `Spec:` linkage line in the plan)
@@ -484,6 +484,8 @@ For each feature (in order):
 
 ### 3.5b. Plan Approval
 
+Before presenting the plan to the user, parse each phase's `**Complexity:**` and `**Complexity rationale:**` fields (added by `arn-code-feature-planner` per its Complexity Assessment section). When presenting the plan summary, **always show the complexity rating per phase** (e.g., `Phase 3: Dispatch Site Edits — 7 deliverables — complexity: complex`).
+
 Ask (using `AskUserQuestion`):
 
 **"Does this plan for F-XXX look right?"**
@@ -493,11 +495,71 @@ Options:
 2. **Adjust** — Let me refine the plan
 3. **Skip this feature** — Remove from the batch
 
-If **Approve**: invoke `Skill: arn-code:arn-code-save-plan`. Proceed to the next feature's plan.
+If **Approve**: run the **Complex Phase Upgrade Gate** below (Step 3.5c) before invoking save-plan. After the gate completes, invoke `Skill: arn-code:arn-code-save-plan`. Proceed to the next feature's plan.
 
-If **Adjust**: let the user provide feedback. Spawn the `arn-code-feature-planner` agent (foreground) with revision instructions and the current plan path. Re-present with the same 3 options. Repeat until approved or skipped.
+If **Adjust**: let the user provide feedback. Spawn the `arn-code-feature-planner` agent via the Task tool (foreground), passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback), with revision instructions and the current plan path. Re-present with the same 3 options. Repeat until approved or skipped.
 
 If **Skip**: remove this feature from the batch. Revert Feature Tracker status to `pending` if applicable. Continue with the next feature's plan.
+
+### 3.5c. Complex Phase Upgrade Gate (with within-session auto-apply)
+
+Before invoking save-plan for an approved plan, check whether to upgrade complex phases to Opus executor. This gate uses **session-scoped memory** for the batch run: the user's answer applies to subsequent batch entries without re-prompting.
+
+**Session memory model** — at batch start, initialize `complexUpgradeSessionAnswer = null`. As batch entries are processed, update this variable based on user answers. The session variable is independent of the persistent preference (which is updated only via the remember-this follow-up).
+
+**Filter:** Build the list of phases in the current plan with `**Complexity:** complex`. If empty, skip this step entirely and proceed to save-plan.
+
+**Check session memory first:** If `complexUpgradeSessionAnswer` is set (from an earlier batch entry):
+- If `yes`: silently mark all complex phases in this plan for `modelOverride: "opus"` (no prompt). Display brief status: `Preference: complex phase upgrade applied to remaining batch entries (session auto-apply)`. Proceed to save-plan.
+- If `no`: silently skip the upgrade for this plan (no prompt). Proceed to save-plan.
+
+**If session memory is null**, do profile detection and the standard preference lookup:
+
+**Profile detection:** Read the project's CLAUDE.md `## Arness` block for `Code agent model profile:`. Branch:
+- If `all-opus`: silently skip this gate. Display status: `Preference: complex phase upgrade silenced — profile is all-opus (no upgrade needed)`. Set `complexUpgradeSessionAnswer = no` (so subsequent entries also silently skip — they'll have the same profile). Proceed to save-plan.
+- If `balanced` or `custom`: continue.
+- If field missing or unknown: treat as `unknown` and continue.
+
+**Two-tier preference lookup** for `pipeline.complex-phase-upgrade` per `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/preferences-schema.md`:
+
+1. Read `.arness/workflow.local.yaml` — if file exists and key present, use that value.
+2. Else read `~/.arness/workflow-preferences.yaml` — if file exists and key present, use that value.
+3. Else treat as `null` (first encounter).
+
+Branch on the resolved value:
+
+- **`always`:** auto-mark every complex phase in this plan for `modelOverride: "opus"`. Set `complexUpgradeSessionAnswer = yes` so subsequent entries auto-apply. Display status. Proceed to save-plan.
+- **`never`:** skip this gate. Set `complexUpgradeSessionAnswer = no`. Proceed to save-plan.
+- **`ask`:** show the gate below. Do NOT show the remember-this follow-up.
+- **`null` (first encounter):** show the gate below. After the user answers, show the remember-this follow-up.
+
+**Gate (shown when value is `ask`, `null`, or invalid):**
+
+Ask (using `AskUserQuestion`):
+
+**"N phases in F-XXX are rated complex (rationale: ...). Upgrade ALL of them to Opus for execution? Reviewer dispatches stay on configured tier. This answer will apply to subsequent batch entries in this session."**
+
+Options:
+1. **Yes, upgrade complex phases** (Recommended for known-complex work) — applies to this plan AND silently to subsequent batch entries
+2. **No, keep configured tier** — no override; applies to this plan AND silently to subsequent batch entries
+
+If **Yes**: mark every complex phase in this plan for `modelOverride: "opus"`. Set `complexUpgradeSessionAnswer = yes`.
+If **No**: no override applied. Set `complexUpgradeSessionAnswer = no`.
+
+**Follow-up (only when preference was null — first encounter):** After the gate, ask:
+
+Ask (using `AskUserQuestion`):
+
+**"Should Arness remember this choice for future sessions?"**
+
+Options:
+1. **Yes, always upgrade complex phases** (saves `always` to preferences — applies to this batch and all future sessions)
+2. **Yes, never upgrade complex phases** (saves `never` to preferences — applies to this batch and all future sessions)
+3. **No, ask me each time** (saves `ask` — within this batch the session-scoped answer above still controls subsequent entries; future batch sessions will fire the gate again on the first complex plan)
+
+Write the chosen value to `~/.arness/workflow-preferences.yaml` under `pipeline.complex-phase-upgrade` per the standard write protocol in preferences-schema.md.
+
+After the gate completes, proceed to save-plan invocation.
 
 ---
 

--- a/plugins/arn-code/skills/arn-code-batch-simplify/SKILL.md
+++ b/plugins/arn-code/skills/arn-code-batch-simplify/SKILL.md
@@ -32,7 +32,7 @@ If no `## Arness` section exists in the project's CLAUDE.md, inform the user: "A
 
 ### Step 0: Ensure Configuration
 
-Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/ensure-config.md` and follow its instructions. Extract from `## Arness`:
+Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/step-0-fast-path.md` and follow its instructions. Extract from `## Arness`:
 
 - **Plans directory** (default: `.arness/plans`)
 - **Code patterns** path (default: `.arness`)
@@ -116,7 +116,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-batch-simplify/references/cross-feat
 
 Build the `{cross_feature_context}` block from the data collected in Step 2 — listing each feature's name, its files, and its change record path.
 
-Dispatch three Agent tool calls **in a single message** so they run in parallel:
+Dispatch three Agent tool calls **in a single message** so they run in parallel. Each call passes the model from `.arness/agent-models/code.md` (look up `arn-code-simplify-reviewer`) as the `model` parameter (see `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/step-0-fast-path.md` "Dispatch convention" for fallback behavior). The three reviewers share the same synthetic name — apply the multi-agent rule by passing the looked-up value to each call independently. Note: `arn-code-simplify-reviewer` is shared with `arn-code-simplify` since both skills perform the same conceptual review work.
 
 1. **Code Reuse Reviewer** — fill the cross-feature-prompts.md template with the file list, pattern documentation, and cross-feature context. Instruct the agent to focus on duplicated logic, missed utilities, and copy-paste patterns, with special attention to utilities created independently by different features.
 
@@ -209,26 +209,62 @@ The user may also change individual finding statuses (e.g., "approve SIM-001 but
 
 ### Step 7: Apply Approved Simplifications
 
-For each approved finding, in dependency order (if finding B depends on finding A's changes, apply A first):
+The orchestrator pre-sorts the approved findings by dependency order (if finding B depends on finding A's changes, A comes first), then dispatches a single anonymous Agent call to perform the apply work. The model is configurable via the agent-models config.
 
-1. Apply the suggested fix.
+**Dispatch the applier as an anonymous Agent tool call**, passing the model from `.arness/agent-models/code.md` (look up `arn-code-simplify-applier`) as the `model` parameter (see `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/step-0-fast-path.md` "Dispatch convention" for fallback behavior). Do NOT add any tool restriction — the applier inherits `Edit`, `Write`, `Bash`, `Read`, `Grep`, `Glob` from the orchestrator's toolbelt by default, and needs all of them. Note: `arn-code-simplify-applier` is shared with `arn-code-simplify` since both skills perform the same conceptual apply work; the cross-feature scope is conveyed via the findings list itself.
 
-2. Run targeted tests relevant to the modified files:
-   - Use the test command from testing-patterns.md
-   - Only run tests covering the modified files, not the full suite
+**Applier prompt contents:**
 
-3. If tests pass: mark the finding as `"applied"`. Record in `applicationResults`.
+- The pre-sorted list of approved findings (each with `id`, `title`, `description`, `suggestedFix`, `filesAffected`, `axis`, and `affectedFeatures`)
+- The targeted-test command (from testing-patterns.md)
+- Paths to relevant pattern docs (code-patterns.md, testing-patterns.md) so the applier can reference them when self-healing
+- The exact instructions below:
 
-4. If tests fail: attempt self-healing.
-   - Fix the implementation issue that caused the failure.
-   - Re-run the targeted tests.
+```
+For each finding in the provided list, IN ORDER:
+
+1. Capture pre-state: `git diff --no-color HEAD > /tmp/pre-{findingId}.diff`
+2. Apply the suggested fix (Edit/Write the affected files).
+3. Run the targeted test command. Capture stdout+stderr.
+4. If tests pass: emit `[FINDING-{findingId}: applied]` to stdout. Record status `"applied"`. Continue to next finding.
+5. If tests fail: attempt self-healing.
+   - Re-read the test output to identify the failure cause.
+   - Make a fix attempt (Edit the file).
+   - Re-run the targeted test command.
    - Up to 3 self-heal attempts per finding.
+6. If tests still fail after 3 attempts: revert this finding's changes via `git apply -R /tmp/pre-{findingId}.diff` (or, if the diff is empty because no prior changes existed, run `git checkout -- {filesAffected}`). Emit `[FINDING-{findingId}: reverted - <reason>]` to stdout. Record status `"reverted"` with the failure reason and last test output. Continue to next finding.
+7. Always emit a per-finding status line so the user sees progress in the transcript.
 
-5. If tests still fail after 3 attempts: **revert** the changes for this specific finding. Mark as `"reverted"` with the failure reason. Record in `applicationResults` and `testVerification.revertedFindings`.
+After processing all findings, run ONE final targeted test pass to verify the cumulative state is consistent. Capture the result.
 
-6. Proceed to the next finding regardless of whether this one was reverted.
+RETURN — strictly as the final message — a JSON object with this exact schema (no other text):
 
-After all approved findings are processed, run one final targeted test pass to verify the cumulative changes are consistent.
+{
+  "applicationResults": [
+    {
+      "findingId": "SIM-001",
+      "status": "applied" | "reverted",
+      "attempts": <integer 1-4>,
+      "testOutput": "<last test command output, truncated to 2000 chars>",
+      "revertReason": "<reason if reverted, omitted if applied>"
+    }
+  ],
+  "finalTestResult": {
+    "passed": <boolean>,
+    "output": "<final test pass output, truncated to 2000 chars>"
+  }
+}
+
+If you crash or have to abort partway through, return the JSON with results for the findings you DID process — do not omit the JSON entirely. Mark unprocessed findings as `status: "pending"` so the orchestrator can surface the partial state.
+```
+
+**After the applier returns:**
+
+1. Parse the returned JSON. If parsing fails or the schema is incomplete, treat any missing finding as `status: "pending"` and add a warning to the report's `warnings` array: `"Applier returned malformed or partial results. <N> findings have unknown status."`
+2. Populate the report's `applicationResults` array directly from the applier's return.
+3. Populate `testVerification.revertedFindings` from any entries with `status: "reverted"`.
+4. Populate `testVerification.finalTestPassed` from `finalTestResult.passed`.
+5. Format a brief user-facing summary from the per-finding statuses for display.
 
 ---
 
@@ -339,5 +375,5 @@ If no fixes were applied (all findings were rejected, deferred, or reverted), sk
 - Each self-heal cycle gets at most 3 attempts before revert.
 - Per-finding revert: a failed finding does not affect other successfully applied findings.
 - Never modify files outside the unified scope's file list without explicit user approval.
-- Anonymous Agent tool calls only — no named agent files for reviewers.
+- Reviewer and applier dispatches use synthetic agent names for model-config lookup; no agent files are required.
 - Report is written to `.arness/plans/BATCH_SIMPLIFICATION_REPORT.json`, not inside any feature subdirectory.

--- a/plugins/arn-code/skills/arn-code-bug-spec/SKILL.md
+++ b/plugins/arn-code/skills/arn-code-bug-spec/SKILL.md
@@ -19,7 +19,7 @@ This is a conversational skill. It runs in normal conversation (NOT plan mode). 
 
 ## Step 0: Ensure Configuration
 
-Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/ensure-config.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/step-0-fast-path.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
 
 ## Workflow
 
@@ -81,7 +81,7 @@ Hold this context for use throughout the conversation. Do not dump all of it on 
 
 ### Step 3: Initial Investigation + Architectural Validation
 
-Invoke the `arn-code-investigator` agent with:
+Invoke the `arn-code-investigator` agent via the Task tool, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 **Bug description:** The user's report from Step 1.
 
@@ -89,7 +89,7 @@ Invoke the `arn-code-investigator` agent with:
 
 **Specific hypothesis:** None for the initial invocation.
 
-Once the investigator returns with a root cause and proposed fix direction, invoke the `arn-code-architect` agent with:
+Once the investigator returns with a root cause and proposed fix direction, invoke the `arn-code-architect` agent via the Task tool, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 **Feature idea:** The investigator's findings -- root cause, scope assessment, and proposed fix direction.
 
@@ -137,7 +137,7 @@ Present the fix proposal with specific files and test plan, offer the user a cho
 
 1. Inform the user: "This fix is complex enough to benefit from a structured plan. Let me capture the investigation results in a specification."
 
-2. Invoke the `arn-code-architect` agent with:
+2. Invoke the `arn-code-architect` agent via the Task tool, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
    - The root cause analysis from the investigator
    - The full codebase context from Step 2
    - A fix design question: "Design a fix approach for this bug that aligns with the system architecture."

--- a/plugins/arn-code/skills/arn-code-catch-up/SKILL.md
+++ b/plugins/arn-code/skills/arn-code-catch-up/SKILL.md
@@ -19,7 +19,7 @@ This is a standalone skill. It operates outside the main pipeline and can be run
 
 ## Step 0: Ensure Configuration
 
-Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/ensure-config.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/step-0-fast-path.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
 
 ---
 

--- a/plugins/arn-code/skills/arn-code-ensure-config/SKILL.md
+++ b/plugins/arn-code/skills/arn-code-ensure-config/SKILL.md
@@ -6,17 +6,19 @@ description: >-
   configuration is present for the current project. This skill is primarily consumed
   as a reference by entry-point skills (arn-planning, arn-implementing, arn-shipping,
   arn-reviewing-pr, arn-assessing, arn-code-feature-spec, arn-code-bug-spec,
-  arn-code-swift, arn-code-standard) which read the ensure-config reference as
-  Step 0 before proceeding with their workflow.
-version: 1.2.0
+  arn-code-swift, arn-code-standard) which read the `references/step-0-fast-path.md`
+  reference as Step 0 before proceeding with their workflow.
+version: 1.3.0
 ---
 
 # Arness Code Ensure Config
 
-Verify and establish Arness Code configuration for the current project. This skill guarantees that a valid user profile and `## Arness` section exist before any Arness Code workflow proceeds. It runs automatically as Step 0 of all entry-point skills.
+Verify and establish Arness Code configuration for the current project. This skill guarantees that a valid user profile and `## Arness` section exist before any Arness Code workflow proceeds. It runs automatically as Step 0 of all entry-point skills via a hash-based fast-path cache.
 
-When invoked directly, it performs the same checks and setup as when called by an entry-point skill.
+**Entry points should NOT read this SKILL.md directly.** They should read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/step-0-fast-path.md`, which runs the cache-check shell script and only falls through to the full validation when needed. This indirection is what saves ~95% of ensure-config token cost.
+
+When invoked DIRECTLY (rare — typically via `/arn-code-ensure-config`), this skill bypasses the cache and runs the full validation flow.
 
 ## Workflow
 
-Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/ensure-config.md` and follow its instructions.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/ensure-config.md` and follow its instructions (Layers 1–3, then Layer 4 cache write).

--- a/plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md
+++ b/plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md
@@ -6,66 +6,6 @@ Follow the layers below in order. Each layer has a fast path (skip when already 
 
 ---
 
-## Layer 0: Migration Check (Nova to Arness)
-
-This layer runs before everything else. It silently migrates legacy Nova artifacts to the Arness naming convention. All steps are idempotent — safe to run multiple times. No user prompts; log-only.
-
-### 0a. Project Directory
-
-Check via Bash:
-```bash
-test -d .nova && echo "OLD_EXISTS" || echo "OLD_MISSING"
-test -d .arness && echo "NEW_EXISTS" || echo "NEW_MISSING"
-```
-
-- If `.nova/` exists AND `.arness/` does NOT exist: run `mv .nova .arness`. Log: "Migrated project directory: .nova/ -> .arness/"
-- If both exist: skip (safety). Log: "Both .nova/ and .arness/ exist — skipping directory migration"
-- Otherwise: no action needed.
-
-### 0b. CLAUDE.md Config Section
-
-Read CLAUDE.md (if it exists) and check for `## Nova` and `## Arness` headers.
-
-- If `## Nova` exists AND `## Arness` does NOT exist: replace `## Nova` with `## Arness` in CLAUDE.md. Log: "Migrated config section: ## Nova -> ## Arness"
-- If both exist: skip (safety). Log: "Both ## Nova and ## Arness sections exist — skipping section migration"
-- Otherwise: no action needed.
-
-### 0c. User Home Directory
-
-Check via Bash:
-```bash
-test -d ~/.nova && echo "OLD_EXISTS" || echo "OLD_MISSING"
-test -d ~/.arness && echo "NEW_EXISTS" || echo "NEW_MISSING"
-```
-
-- If `~/.nova/` exists AND `~/.arness/` does NOT exist: run `mv ~/.nova ~/.arness`. Log: "Migrated user directory: ~/.nova/ -> ~/.arness/"
-- If both exist: skip (safety). Log: "Both ~/.nova/ and ~/.arness/ exist — skipping user directory migration"
-- Otherwise: no action needed.
-
-### 0d. Gitignore
-
-Read `.gitignore` (if it exists) and check for `.nova/*.local.yaml`.
-
-- If `.gitignore` contains `.nova/*.local.yaml` but NOT `.arness/*.local.yaml`: replace `.nova/*.local.yaml` with `.arness/*.local.yaml`. Log: "Updated .gitignore: .nova/*.local.yaml -> .arness/*.local.yaml"
-- If both patterns exist: skip (safety).
-- Otherwise: no action needed.
-
-### 0e. Profile Reference
-
-Check via Bash:
-```bash
-test -f .claude/nova-profile.local.md && echo "OLD_EXISTS" || echo "OLD_MISSING"
-test -f .claude/arness-profile.local.md && echo "NEW_EXISTS" || echo "NEW_MISSING"
-```
-
-- If `.claude/nova-profile.local.md` exists AND `.claude/arness-profile.local.md` does NOT exist: run `mv .claude/nova-profile.local.md .claude/arness-profile.local.md`. Log: "Migrated profile: nova-profile.local.md -> arness-profile.local.md"
-- If both exist: skip (safety).
-- Otherwise: no action needed.
-
-After all migration steps complete (or are skipped), proceed to Layer 1.
-
----
-
 ## Layer 1: Profile Check (Welcome & Profile)
 
 ### 1a. Check for Existing Profile
@@ -159,12 +99,12 @@ technology_preferences:
 expertise_aware: true | false
 ```
 
-3. Verify `.claude/*.local.md`, `.claude/settings.local.json`, and `.arness/*.local.yaml` are in the project's `.gitignore`:
+3. Verify `.claude/*.local.md`, `.claude/settings.local.json`, and `.arness/*.local.*` are in the project's `.gitignore`:
    - Read `.gitignore` in the project root
-   - If `.gitignore` does not exist, create it with `.claude/settings.local.json`, `.claude/*.local.md`, and `.arness/*.local.yaml` as entries
+   - If `.gitignore` does not exist, create it with `.claude/settings.local.json`, `.claude/*.local.md`, and `.arness/*.local.*` as entries
    - If `.gitignore` exists but does not contain `.claude/*.local.md`, append `.claude/*.local.md` on a new line
    - If `.gitignore` exists but does not contain `.claude/settings.local.json`, append `.claude/settings.local.json` on a new line
-   - If `.gitignore` exists but does not contain `.arness/*.local.yaml`, append `.arness/*.local.yaml` on a new line
+   - If `.gitignore` exists but does not contain `.arness/*.local.*`, append `.arness/*.local.*` on a new line
    - **Important:** Do NOT gitignore the entire `.claude/` directory — `.claude/settings.json` and other project-level Claude Code settings should remain committable for team sharing.
    - **Important:** Do NOT gitignore the entire `.arness/` directory — `.arness/preferences.yaml` (team technology preferences) and other Arness project files must remain committable.
 4. Optionally create `.claude/arness-profile.local.md` if the user wants project-specific adjustments
@@ -188,6 +128,7 @@ Proceed to Layer 2.
 - `Code patterns`
 - `Docs directory`
 - `Linting`
+- `Code agent model profile`
 
 Layer 2a reads CLAUDE.md. Layer 2b runs if no `## Arness` section exists. Layer 2c runs if **any** required field is missing — including `Linting`. Layer 2d only fast-paths when **every** required field above is present. The `Linting` field was added later than the other fields, so it is common for an existing `## Arness` block to have all the original fields but be missing `Linting` — that case must route to 2c, not fast-path through 2d.
 
@@ -236,6 +177,8 @@ Ask (using `AskUserQuestion`):
 Construct the `## Arness` section with all fields. If CLAUDE.md does not exist, create it with the `## Arness` section. If CLAUDE.md exists, append the section at the end.
 
 For the `Linting:` field: this is a fast-path defaulted to `skip` here. The first time a code-generating skill runs (executor, ship, etc.) the user will be prompted by Layer 2c-style logic to confirm. Do not invoke the codebase-analyzer here — keep this fast path lightweight. Setting `skip` is safe because it means "no lint gate"; the user can opt in later.
+
+For the `Code agent model profile:` field: do NOT default it here. Leave the field absent so Layer 2c routes to the **Profile selection** procedure (see "Model profile field" section below) on the next ensure-config invocation. This guarantees the user is asked rather than silently set to `all-opus`. The corresponding `.arness/agent-models/code.md` file is created by the Profile selection procedure, not by this fast path.
 
 Fields to write:
 ```
@@ -298,9 +241,30 @@ If the `Linting:` field is missing (separate logic — this field is not a direc
 
 The Linting field is intentionally handled separately from directory fields: directories have safe defaults; linting requires a real choice because it gates commits.
 
-### 2d. If `## Arness` Exists and ALL Required Fields (Including Linting) Are Present
+If the `Code agent model profile:` field is missing (separate logic — this field requires a real choice and downstream artifact copy):
 
-**Fast path.** Before silently proceeding, verify against the **Required Arness Code fields** list at the top of Layer 2 — every field on that list must be present in the existing `## Arness` block. If any are missing, route to Layer 2c instead (do NOT fast-path).
+1. Run the **Profile selection** procedure documented in the "Model profile field" section below. The procedure handles the AskUserQuestion prompt, writes the field to the `## Arness` block, copies the chosen preset to `.arness/agent-models/code.md`, and records the SHA-256 checksum.
+
+If the `Code agent model profile:` field is **present** (Layer 2d-style consistency check — runs before the fast path completes):
+
+1. **If value is `all-opus` or `balanced`:**
+   a. Compute the SHA-256 checksum of `.arness/agent-models/code.md` and compare it to the recorded checksum in `.arness/agent-models/.checksums.json`.
+   b. If checksums **differ** (user edited the file): flip the field value in `## Arness` from its current value to `custom` and inform the user with a one-line message: `"Detected your edits to .arness/agent-models/code.md — set profile to 'custom' so future updates won't overwrite your changes."` Do NOT overwrite the user's edits; do NOT recompute the checksum (the `custom` profile means "user-managed").
+   c. If checksums match: read the `# Version:` header from `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-init/references/agent-models-presets/<value>.md` (the upstream preset) and compare to the `# Version:` header recorded in `.arness/agent-models/code.md`. If they differ, apply the project's `Template updates:` policy (reuse the procedure in `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-save-plan/references/template-versioning.md`):
+      - `auto`: copy the new preset, regenerate the checksum, inform the user "Refreshed `.arness/agent-models/code.md` from preset `<value>` v<old>→v<new>."
+      - `ask`: prompt the user; on accept, copy + regenerate; on decline, leave file alone and skip until the user re-runs.
+      - `manual`: do nothing this run.
+
+2. **If value is `custom`:**
+   a. Read the canonical agent list from `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-init/references/agent-models-presets/all-opus.md` (every entry of the form `<agent-name>: <model>`).
+   b. Read the user's `.arness/agent-models/code.md` and collect the agent names present.
+   c. For any agent in the canonical list that is NOT present in the user's file, surface as an info-level diagnostic: `"Note: .arness/agent-models/code.md is missing entries for: <comma-separated agent list>. Add them or run with 'all-opus'/'balanced' profile to refresh."` This is informational only — do not block the workflow.
+
+3. **If value is anything else** (legacy/typo): treat as missing — run the Profile selection procedure to repair.
+
+### 2d. If `## Arness` Exists and ALL Required Fields (Including Linting and Code agent model profile) Are Present
+
+**Fast path.** Before silently proceeding, verify against the **Required Arness Code fields** list at the top of Layer 2 — every field on that list must be present in the existing `## Arness` block. If any are missing, route to Layer 2c instead (do NOT fast-path). The `Code agent model profile:` checksum/version/custom-diagnostic checks documented in Layer 2c also run here whenever the field is present, even on the fast path — they are cheap and idempotent.
 
 If all required fields are present, no action needed; proceed to Layer 3.
 
@@ -329,6 +293,137 @@ No label creation needed. Jira labels are implicit (created on first use by Jira
 
 ---
 
+## Layer 4: Cache Write
+
+After Layers 1–3 complete successfully, write the validation cache so future ensure-config invocations can fast-path via `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/scripts/cache-check.sh`. This is the final step of the validation flow.
+
+### Why a cache?
+
+Entry-point skills invoke ensure-config as Step 0 on every workflow trigger (~30 trigger points across the plugin). Re-running the full Layers 1–3 flow on every invocation costs ~2k tokens even when nothing has changed. The cache lets the cache-check shell script (zero model tokens) verify validity in milliseconds; on hit, the entry-point skips reading this references file entirely (per the procedure in `references/step-0-fast-path.md`).
+
+### Cache file location
+
+`.arness/arn-code-ensure-config.local.json` (project-local, gitignored via the `.arness/*.local.*` pattern from Layer 1c).
+
+### Cache schema
+
+```json
+{
+  "schemaVersion": 1,
+  "validatedAt": "2026-05-10T12:34:56Z",
+  "pluginVersion": "3.7.0",
+  "fingerprints": {
+    "claudeMdArnessSection": "<sha256 of the ## Arness block content>",
+    "agentModelsCodeMd": "<sha256 of .arness/agent-models/code.md, or 'MISSING'>",
+    "agentModelsChecksums": "<sha256 of .arness/agent-models/.checksums.json, or 'MISSING'>",
+    "templatesChecksums": "<sha256 of .arness/templates/.checksums.json, or 'MISSING'>",
+    "userProfile": "<sha256 of ~/.arness/user-profile.yaml, or 'MISSING'>",
+    "profileOverride": "<sha256 of .claude/arness-profile.local.md, or 'MISSING'>",
+    "gitignoreContent": "<sha256 of .gitignore, or 'MISSING'>"
+  },
+  "validationStatus": "pass"
+}
+```
+
+### Write procedure
+
+1. **Compute the 7 fingerprints** using `sha256sum` (Linux + Git Bash) || `shasum -a 256` (Mac BSD). For the `claudeMdArnessSection` hash, extract the `## Arness` block via `awk '/^## Arness$/{flag=1;next} /^## /{flag=0} flag' CLAUDE.md` then pipe to the hasher. For each file fingerprint: if the file does not exist, use the literal string `MISSING` instead of computing a hash.
+
+2. **Read plugin version** from `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json` if present (legacy), else from the marketplace's `marketplace.json` entry for `arn-code`. Use the empty string if neither is resolvable (cache will not enforce version match in that case).
+
+3. **Construct the JSON object** with the schema above. `validatedAt` is the current ISO 8601 UTC timestamp. `validationStatus` is `"pass"` (only written on successful Layers 1–3).
+
+4. **Write atomically** using a project-local temp file (NOT `/tmp/` — Windows compat):
+
+   ```bash
+   <json content> > .arness/arn-code-ensure-config.local.json.tmp
+   mv .arness/arn-code-ensure-config.local.json.tmp .arness/arn-code-ensure-config.local.json
+   ```
+
+   The `mv` is atomic on POSIX filesystems (Linux ext4, Mac APFS, Windows NTFS via Git Bash). On any Ctrl-C between the write and the mv, the partial file lives at `.local.json.tmp` and the previous cache (if any) is untouched.
+
+5. **Verify** by reading the file back and confirming valid JSON. If the verify fails, surface as a warning but do not block — the next invocation will simply cache-miss.
+
+### When the cache invalidates
+
+- `pluginVersion` differs from current (plugin upgrade)
+- `schemaVersion` differs from current (cache schema bump — silently invalidates)
+- Any of the 7 fingerprints differs from current state (user edited CLAUDE.md `## Arness`, agent-models file, gitignore, profile, etc.)
+- GitHub `arness-*` label count != 7 (when Platform=github and `gh` CLI available — checked inline in `cache-check.sh`, not stored in the JSON)
+
+All invalidation paths trigger a cache miss, which causes the entry-point to read the full ensure-config.md and re-run Layers 1–3 — at the end of which this Layer 4 step writes a new cache.
+
+---
+
+## Model profile field
+
+The `Code agent model profile` field controls which Claude model each Arness Code agent is dispatched on. It mirrors the structure of the `Linting` field flow and reuses the same checksum + version-update machinery as report templates.
+
+### Field summary
+
+| Property | Value |
+|----------|-------|
+| Field name | `Code agent model profile` |
+| Valid values | `all-opus` \| `balanced` \| `custom` |
+| Default on init | `all-opus` (preserves prior behavior) |
+| Where the choice lives | The field in `## Arness` records the user's choice; the actual model-per-agent map lives at `.arness/agent-models/code.md`. |
+| Update policy | Reuses the project's `Template updates:` field (`ask` \| `auto` \| `manual`). |
+| Drift detection | SHA-256 checksum of `.arness/agent-models/code.md` compared to the recorded checksum. Mismatch flips the field to `custom`. |
+| Custom diagnostic | When value is `custom`, missing-agent entries (against the canonical `all-opus.md` agent list) are surfaced as info-level diagnostics. |
+| User example | The arness repo's own `## Arness` block currently uses `Linting: skip`, `Template path: .arness/templates`, `Template version: 2.3.0`, `Template updates: ask`. The model-profile field is appended in the same `- **Field name:** value` style. |
+
+### Profile selection procedure
+
+This procedure is the single source of truth for the prompt + write + copy + checksum flow. It is invoked from two places:
+- `arn-code-init` ("Choose model profile" step), and
+- `arn-code-ensure-config` Layer 2c (when the field is missing).
+
+Both call sites must read this section and follow it verbatim — do NOT duplicate the AskUserQuestion + write + copy + checksum logic at the call sites.
+
+**Steps:**
+
+1. **Cross-plugin default suggestion.** Before asking, read the project's CLAUDE.md `## Arness` block. If a sibling plugin's profile field (`Spark agent model profile:` or `Infra agent model profile:`) is set to `all-opus` or `balanced`, suggest that value as the default in the AskUserQuestion options ordering (the recommended/default option goes first, with `(Recommended)` appended). If both siblings are set to different values, prefer the most recently written field; if neither is set, the default is `all-opus`.
+
+2. **Ask the user.** Ask (using `AskUserQuestion`):
+
+   > **Choose model profile for arn-code agents**
+   > 1. **all-opus (Recommended)** — Every agent uses Opus. Maximum quality, maximum cost. (Current behavior.)
+   > 2. **balanced** — Opus for heavy reasoning, Sonnet for operational work. Lower cost, similar quality on routine tasks.
+
+   The label `(Recommended)` is appended to the suggested default (which may be `balanced` if a sibling plugin chose `balanced`). The recommended option appears first in the option list.
+
+3. **Write the field.** Append `- **Code agent model profile:** <choice>` to the `## Arness` block in CLAUDE.md, using the existing field-write idiom (preserve all other fields, replace the single field if it already exists).
+
+4. **Copy the preset.** Create `.arness/agent-models/` if it does not exist (`mkdir -p .arness/agent-models`). Copy `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-init/references/agent-models-presets/<choice>.md` to `.arness/agent-models/code.md`.
+
+5. **Record the checksum.** Compute the SHA-256 checksum of the copied file via Bash:
+   ```bash
+   sha256sum .arness/agent-models/code.md 2>/dev/null || shasum -a 256 .arness/agent-models/code.md
+   ```
+   Read or create `.arness/agent-models/.checksums.json`. Add or update the entry for `code.md`:
+   ```json
+   {
+     "code.md": {
+       "sha256": "<hex digest>",
+       "profile": "<choice>",
+       "version": "<version from the preset's # Version: header>"
+     }
+   }
+   ```
+   Preserve any sibling entries (`spark.md`, `infra.md`) already present in `.checksums.json` — those belong to the other plugins and are managed by their own ensure-config flows.
+
+6. **Inform the user** with a one-line confirmation: `"Set Code agent model profile to <choice>. Wrote .arness/agent-models/code.md (sha256: <first-8-chars>...)."`
+
+### Drift detection (Layer 2c integration)
+
+Layer 2c runs steps 1-3 of the following whenever the field is present:
+
+1. **Checksum check.** Compute the current sha256 of `.arness/agent-models/code.md` and compare to the recorded checksum in `.arness/agent-models/.checksums.json`. If they differ, flip the field to `custom` (one-line user message; do NOT overwrite the user's file).
+2. **Version check** (only when value is `all-opus` or `balanced` and checksums match): compare the `# Version:` header in the user's `.arness/agent-models/code.md` against the upstream preset at `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-init/references/agent-models-presets/<value>.md`. On mismatch, apply the `Template updates:` policy (reuse `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-save-plan/references/template-versioning.md`).
+3. **Custom diagnostic** (only when value is `custom`): read the canonical agent list from `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-init/references/agent-models-presets/all-opus.md` and surface info-level diagnostics for any canonical agent missing from the user's file.
+
+---
+
 ## Important Rules
 
 1. **Never hard-block.** If auto-detection fails for a non-critical field (Platform, Issue tracker), default gracefully (`none`). Only the profile welcome flow is mandatory on first invocation.
@@ -339,3 +434,26 @@ No label creation needed. Jira labels are implicit (created on first use by Jira
 6. **Profile data is non-sensitive** (role, technology preferences — no credentials or secrets). The `.claude/*.local.md` gitignore pattern protects against accidental commits of the project-level override while keeping `.claude/settings.json` committable for team sharing.
 7. **Folder preference coordination:** When setting `Folder preference`, this value is shared across all three plugins. If another plugin already set it, respect that value.
 8. **Template version field** must be set from the plugin version in `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json`, not hardcoded.
+
+---
+
+## Dispatch convention (agent model lookup)
+
+Every skill in this plugin that dispatches a subagent via the Task tool consults a per-plugin model profile to decide which model the agent runs on. The profile lives at `.arness/agent-models/code.md` (project-relative, NOT plugin-relative — this path is project-rooted while plugin assets use `${CLAUDE_PLUGIN_ROOT}` per Pattern 8 in INTRODUCTION.md). The file is created during init and is one of the presets shipped under `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-init/references/agent-models-presets/`.
+
+### Lookup procedure (apply at every dispatch site)
+
+1. **Read `.arness/agent-models/code.md`** (project-relative).
+2. **If the file is missing or unparseable:** omit the `model:` parameter when invoking the Task tool. The agent's frontmatter default (`opus`) applies. Do not surface an error — fallback is silent.
+3. **Look up the agent's name** (e.g., `arn-code-feature-planner`, `arn-code-task-executor`) in the file's mapping.
+4. **If the agent name is found:** pass the mapped value (e.g., `opus`, `sonnet`, `haiku`) as the Task tool's `model` parameter. This overrides the agent's `model:` frontmatter.
+5. **If the agent name is NOT found in the file:** omit the `model:` parameter — frontmatter fallback applies. This keeps user-edited `custom` profiles forward-compatible: agents added to the plugin after the user customized their profile still run on their frontmatter default (`opus`) until the user adds them to the file.
+6. **Multi-agent parallel dispatches:** apply the lookup to each agent independently. A single instruction that spawns three agents in parallel produces three independent lookups, each potentially passing a different `model:` value.
+7. **Resume-mode dispatches** (calls that pass an existing agent ID via the Task tool's `resume` parameter): do NOT consult the profile. Resume calls inherit the model from the original invocation. Dispatch sites that resume an existing agent do not include the model-lookup phrasing.
+
+### Why this design
+
+- **Native Task tool support.** The Task tool's `model:` parameter takes precedence over agent frontmatter (Pattern 2 in INTRODUCTION.md). No wrapper or shim is needed.
+- **Self-documenting.** Every dispatch site explicitly references this convention, so the lookup behavior is visible at the point of dispatch rather than buried in a global default. A static grep for `via the Task tool` confirms coverage.
+- **Graceful degradation.** Missing file, missing agent entry, and unparseable content all fall back to frontmatter — there is no failure mode where dispatch hangs or errors on a config issue.
+- **Single source of truth.** `.arness/agent-models/code.md` is the only place a user edits to change behavior across all arn-code dispatches. The file is template-managed (Pattern 6) so version bumps, drift detection, and the `Template updates: ask | auto | manual` policy all apply.

--- a/plugins/arn-code/skills/arn-code-ensure-config/references/preferences-schema.md
+++ b/plugins/arn-code/skills/arn-code-ensure-config/references/preferences-schema.md
@@ -16,6 +16,7 @@ pipeline:
   sketch-preview: always | never | ask
   simplification: always | auto-all | skip | ask
   expert-debate: standard | auto | ask
+  complex-phase-upgrade: always | never | ask
 ```
 
 ### Key Definitions
@@ -28,6 +29,7 @@ pipeline:
 | `sketch-preview` | `always` = generate sketch preview; `never` = skip sketch preview; `ask` = show gate each time (no follow-up) | arn-code-swift 2b, arn-code-standard 2b |
 | `simplification` | `always` = run simplification pass; `auto-all` = run simplification and auto-approve all non-deferred findings without prompting (used by batch-implement workers); `skip` = skip simplification; `ask` = show gate each time (no follow-up) | arn-implementing G3, arn-code-swift 4b/5b, arn-code-standard 5b, arn-code-batch-implement workers |
 | `expert-debate` | `standard` = standard spec (no expert debate); `auto` = propose expert debate when scope score is 16+ (see threshold below); `ask` = show gate each time (no follow-up) | arn-planning G2 |
+| `complex-phase-upgrade` | `always` = auto-upgrade executor to Opus for any phase the planner rates `complex`; `never` = never upgrade (skip the gate silently); `ask` = show the all-or-none gate each time (no follow-up). See "Complex Phase Upgrade" section below for the silence rule and within-batch auto-apply behavior. | arn-code-plan Step 5, arn-code-batch-planning per-batch-entry |
 
 ---
 
@@ -172,6 +174,46 @@ When `expert-debate` resolves to `auto`:
 
 ---
 
+## Complex Phase Upgrade
+
+When `complex-phase-upgrade` resolves to a non-null value, the gate at `arn-code-plan` Step 5 (and `arn-code-batch-planning` per-batch-entry) checks the planner's per-phase complexity ratings AND the active model profile before deciding whether to fire.
+
+### Profile-aware silence
+
+The gate is **silently skipped** when the active model profile is `all-opus` (read from CLAUDE.md `## Arness` block: `Code agent model profile:`). Rationale: every agent is already on Opus, so there is nothing to upgrade. The gate would be a no-op prompt.
+
+The gate fires when the profile is `balanced`, `custom`, or undetectable (treat unknown as a runs-the-gate condition — the user gets the choice; if they accept, the override propagates regardless of any agent-models lookup).
+
+### Gate granularity: all-or-none per plan
+
+When at least one phase in the plan is rated `complex`, the gate prompt is **all-or-none**: "N phases are rated complex (rationale: ...) — upgrade ALL of them to Opus for execution? Yes / No". This gives the user one decision per plan. Per-task or per-phase Y/N would create excessive friction; users can still do per-task overrides via `/arn-code-execute-task` with manual model override.
+
+If the user accepts, every `complex` phase in the plan gets `implementation.modelOverride: "opus"` written to PROGRESS_TRACKER.json by `arn-code-save-plan`. Phases rated `simple` or `moderate` are NOT upgraded.
+
+### Within-batch auto-apply (arn-code-batch-planning only)
+
+`arn-code-batch-planning` produces multiple plans in sequence. When the gate fires for the first plan with complex phases in a batch session, the user's answer is captured in **session-scoped memory** for that batch run AND optionally persisted to `~/.arness/workflow-preferences.yaml` via the standard remember-this follow-up.
+
+- If the user answers Yes (with no remember-this) → mark current plan's complex phases for upgrade AND silently auto-apply Yes to subsequent batch entries (no nag mid-batch). Session memory only.
+- If the user answers No (with no remember-this) → no upgrade for current plan AND silently skip the gate for subsequent batch entries.
+- If the user persists `always` via remember-this → applies to current AND subsequent batch entries AND all future sessions.
+- If the user persists `never` via remember-this → no gate fires anywhere.
+- If the user persists `ask` via remember-this → the gate continues to fire per-batch-entry in subsequent batches. Within the current batch, the latest answer still controls subsequent entries (session memory).
+
+This prevents the user from being prompted repeatedly when working through many batch entries with similar complexity profiles.
+
+### Override scope: executor only
+
+The override applies only to the executor agent's dispatch. Reviewer dispatches stay on the configured tier. The user explicitly framed this as an executor upgrade (the agent that does the actual code modification), and reviewers re-run targeted tests + validate against patterns — operational work where Sonnet (in `balanced`) is sufficient.
+
+A future enhancement could add `pipeline.complex-phase-reviewer-upgrade` if data shows reviewer-tier upgrades on complex phases produce meaningfully better outcomes.
+
+### Cost tradeoff
+
+If you find yourself frequently answering Yes to the upgrade gate, consider switching to the `all-opus` profile instead. The `balanced` profile + `complex-phase-upgrade: always` may end up paying Opus cost for most phases anyway, defeating the cost saving. The `complex-phase-upgrade` feature is most useful when you genuinely want `balanced` defaults but are willing to upgrade for known-complex work.
+
+---
+
 ## Status Line Format
 
 When auto-proceeding with a stored preference, display a brief status line. The format depends on the source file:
@@ -195,4 +237,7 @@ Preference: generating sketch preview (stored in workflow-preferences.yaml)
 Preference: running simplification pass (stored in workflow-preferences.yaml)
 Preference: standard spec, no expert debate (stored in workflow-preferences.yaml)
 Preference: expert debate proposed (scope score 18, auto mode in workflow-preferences.yaml)
+Preference: upgrading 3 complex phases to Opus executor (stored in workflow-preferences.yaml)
+Preference: complex phase upgrade silenced — profile is all-opus (no upgrade needed)
+Preference: complex phase upgrade applied to remaining batch entries (session auto-apply)
 ```

--- a/plugins/arn-code/skills/arn-code-ensure-config/references/step-0-fast-path.md
+++ b/plugins/arn-code/skills/arn-code-ensure-config/references/step-0-fast-path.md
@@ -1,0 +1,25 @@
+# Arness Code Ensure-Config — Step 0 Fast-Path
+
+This is the **first read** for entry-point skills' Step 0. It runs a shell-only cache check; if the cache is valid, the entry-point can skip reading the full `references/ensure-config.md` (which is ~457 lines). On cache miss, falls through to the full validation flow.
+
+## Procedure
+
+1. **Run the cache check** via Bash:
+
+   ```
+   bash ${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/scripts/cache-check.sh
+   ```
+
+2. **If exit 0 (cache hit):**
+   - Emit a one-line status to the user: `Ensure-config: cache valid (arn-code, last validated <duration> ago)`. Read the `validatedAt` timestamp from `.arness/arn-code-ensure-config.local.json` to format the duration; if reading fails, just say "cache valid".
+   - Return immediately. The entry-point skill's own workflow proceeds with no further config work.
+   - **Do NOT read `references/ensure-config.md`** — that is the whole point of the fast path.
+
+3. **If exit non-zero (cache miss):**
+   - The script's stderr output includes the reason (e.g., `cache miss: pluginVersion changed`, `cache miss: fingerprint claudeMdArnessSection changed`). Surface it as an info-level note: `Ensure-config: cache miss (<reason>) — running full validation.`
+   - **Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/ensure-config.md`** and follow ALL its instructions (Layer 1: Profile, Layer 2: Config, Layer 3: Platform Labels).
+   - At the end of successful validation, the ensure-config.md flow's "Cache Write" step (final step of Layer 3) writes the new `.arness/arn-code-ensure-config.local.json` per the cache schema documented inline there.
+
+## Cross-platform notes
+
+The cache-check script works on Linux, Mac, and Windows-via-Git-Bash. It requires `bash`, `sha256sum` or `shasum`, `awk`, `grep`, `cat`, and `jq`. The `gh` CLI is optional (used only for GitHub label count verification). If any required tool is missing, the script exits non-zero and full validation runs as the fallback.

--- a/plugins/arn-code/skills/arn-code-ensure-config/scripts/cache-check.sh
+++ b/plugins/arn-code/skills/arn-code-ensure-config/scripts/cache-check.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# arn-code-ensure-config cache-check.sh
+#
+# Returns exit 0 when the cache at .arness/arn-code-ensure-config.local.json
+# is valid (all fingerprints match current state). Returns non-zero with a
+# stderr reason on miss.
+#
+# Cross-platform: works on Linux, Mac, and Windows-via-Git-Bash.
+# Required tools: bash, sha256sum or shasum, awk, grep, mv, cat, jq.
+# Optional tool: gh (only used for GitHub label count check).
+
+set -u
+
+PLUGIN_NAME="arn-code"
+SHORT_NAME="code"
+SCHEMA_VERSION=1
+EXPECTED_LABELS_COUNT=7
+CACHE_FILE=".arness/${PLUGIN_NAME}-ensure-config.local.json"
+
+# --- Helper: fail fast with reason ---
+miss() {
+  echo "cache miss: $1" >&2
+  exit 1
+}
+
+# --- Helper: cross-platform SHA-256 ---
+hash_str() {
+  local data="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$data" | sha256sum | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$data" | shasum -a 256 | awk '{print $1}'
+  else
+    echo "ERROR: neither sha256sum nor shasum available" >&2
+    exit 2
+  fi
+}
+
+hash_file() {
+  local path="$1"
+  if [ ! -f "$path" ]; then
+    echo "MISSING"
+    return 0
+  fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$path" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$path" | awk '{print $1}'
+  else
+    echo "ERROR: neither sha256sum nor shasum available" >&2
+    exit 2
+  fi
+}
+
+# --- 1. Cache file present? ---
+[ -f "$CACHE_FILE" ] || miss "no cache file at $CACHE_FILE"
+
+# --- 2. jq available for parsing? ---
+command -v jq >/dev/null 2>&1 || miss "jq not available (required for cache parsing)"
+
+# --- 3. Schema version matches? ---
+cached_schema=$(jq -r '.schemaVersion // empty' "$CACHE_FILE" 2>/dev/null)
+[ "$cached_schema" = "$SCHEMA_VERSION" ] || miss "schemaVersion mismatch (cache: ${cached_schema:-empty}, expected: $SCHEMA_VERSION)"
+
+# --- 4. Plugin version matches? ---
+# Try to find marketplace.json relative to this script's location.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Script: <plugin-root>/skills/arn-code-ensure-config/scripts/cache-check.sh
+# Plugin root: ../../..
+# Marketplace root: ../../../.. (when installed via relative path / local marketplace)
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+MARKETPLACE_JSON="$(cd "$PLUGIN_ROOT/.." && pwd)/.claude-plugin/marketplace.json"
+
+if [ -f "$MARKETPLACE_JSON" ]; then
+  current_version=$(jq -r --arg name "$PLUGIN_NAME" '.plugins[] | select(.name==$name) | .version' "$MARKETPLACE_JSON" 2>/dev/null)
+  cached_version=$(jq -r '.pluginVersion // empty' "$CACHE_FILE")
+  if [ -n "$current_version" ] && [ "$current_version" != "$cached_version" ]; then
+    miss "pluginVersion changed (cache: $cached_version, current: $current_version)"
+  fi
+fi
+# If marketplace.json is unfindable (Anthropic Community Plugin Directory install, etc.),
+# skip the version check and rely on file-hash invalidation.
+
+# --- 5. Compute current fingerprints ---
+# Hash the ## Arness section of CLAUDE.md
+if [ -f "CLAUDE.md" ]; then
+  arness_section=$(awk '/^## Arness$/{flag=1;next} /^## /{flag=0} flag' CLAUDE.md)
+  current_arness_section_hash=$(hash_str "$arness_section")
+else
+  current_arness_section_hash="MISSING"
+fi
+
+current_agent_models_hash=$(hash_file ".arness/agent-models/${SHORT_NAME}.md")
+current_agent_models_checksums_hash=$(hash_file ".arness/agent-models/.checksums.json")
+current_templates_checksums_hash=$(hash_file ".arness/templates/.checksums.json")
+current_user_profile_hash=$(hash_file "$HOME/.arness/user-profile.yaml")
+current_profile_override_hash=$(hash_file ".claude/arness-profile.local.md")
+current_gitignore_hash=$(hash_file ".gitignore")
+
+# --- 6. Compare against cache ---
+# Use parallel indexed arrays (bash 3.2 compatible — Mac's default /bin/bash is 3.2,
+# associative arrays via 'declare -A' are bash 4+ only).
+KEYS=(claudeMdArnessSection agentModelsCodeMd agentModelsChecksums templatesChecksums userProfile profileOverride gitignoreContent)
+VALUES=(
+  "$current_arness_section_hash"
+  "$current_agent_models_hash"
+  "$current_agent_models_checksums_hash"
+  "$current_templates_checksums_hash"
+  "$current_user_profile_hash"
+  "$current_profile_override_hash"
+  "$current_gitignore_hash"
+)
+
+i=0
+while [ $i -lt ${#KEYS[@]} ]; do
+  key="${KEYS[$i]}"
+  current="${VALUES[$i]}"
+  cached=$(jq -r ".fingerprints.${key} // empty" "$CACHE_FILE")
+  if [ "$cached" != "$current" ]; then
+    miss "fingerprint $key changed (cache: ${cached:0:16}..., current: ${current:0:16}...)"
+  fi
+  i=$((i + 1))
+done
+
+# --- 7. GitHub labels check (only if Platform=github AND gh available) ---
+if [ -f "CLAUDE.md" ]; then
+  platform=$(grep -E '^- \*\*Platform:\*\*' CLAUDE.md 2>/dev/null | head -1 | sed -E 's/.*Platform:\*\*\s*//')
+  if [ "$platform" = "github" ] && command -v gh >/dev/null 2>&1; then
+    label_count=$(gh label list --json name --jq '.[].name' 2>/dev/null | grep -c '^arness-' || echo 0)
+    if [ "$label_count" != "$EXPECTED_LABELS_COUNT" ]; then
+      miss "GitHub arness-* label count is $label_count, expected $EXPECTED_LABELS_COUNT"
+    fi
+  fi
+fi
+
+# --- All checks passed ---
+exit 0

--- a/plugins/arn-code/skills/arn-code-execute-plan/references/dispatch-loop.md
+++ b/plugins/arn-code/skills/arn-code-execute-plan/references/dispatch-loop.md
@@ -34,7 +34,11 @@ WHILE there are pending tasks:
 
   For each unblocked pending task in this batch:
     a. Mark the task as in_progress via TaskUpdate
-    b. Spawn a arn-code-task-executor agent via the Task tool with this prompt:
+    b. **Determine the executor model.** First check the per-phase upgrade override:
+       - Read PROGRESS_TRACKER.json. Find the phase entry whose `implementation.taskId` matches the current task ID.
+       - If `phase.implementation.modelOverride` is non-null (e.g., `"opus"`), use that value as the `model` parameter for this dispatch. Skip the standard agent-models lookup. Emit a one-line status to the user: `Phase <N> (<phaseTitle>) executor model: <override> (upgraded — complex phase per pipeline.complex-phase-upgrade)`.
+       - If `phase.implementation.modelOverride` is null or the field is missing, fall through to the standard lookup: pass the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback).
+    Then spawn a arn-code-task-executor agent via the Task tool with the determined model. Context for the prompt:
        - Task ID and full task description (from TaskGet)
        - Project name: <PROJECT_NAME>
        - Project folder path: <plans-dir>/<PROJECT_NAME>/
@@ -84,7 +88,7 @@ WHILE there are pending tasks:
     a. Read the executor's output to extract:
        - Report file path(s) (implementation report and/or testing report)
        - List of files created and modified
-    b. Spawn a arn-code-task-reviewer agent via the Task tool with this prompt:
+    b. Spawn a arn-code-task-reviewer agent via the Task tool, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context for the prompt:
        - Task ID and full task description
        - Project name: <PROJECT_NAME>
        - Project folder path: <plans-dir>/<PROJECT_NAME>/
@@ -154,7 +158,7 @@ WHILE there are pending tasks:
           - After the executor returns, go back to step 4 for this task only
             (re-run the reviewer)
         - IF review feedback mode = "fresh":
-          - Spawn a NEW arn-code-task-executor agent via the Task tool with:
+          - Spawn a NEW arn-code-task-executor agent via the Task tool, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
             - All original task context (same as step 2b)
             - PLUS: the review report path
             - PLUS: specific findings to fix from the reviewer

--- a/plugins/arn-code/skills/arn-code-execute-plan/references/pattern-refresh.md
+++ b/plugins/arn-code/skills/arn-code-execute-plan/references/pattern-refresh.md
@@ -19,7 +19,7 @@ Automatic post-implementation refresh of stored pattern documentation. After imp
    - If **none exist** AND this **is** a catch-up context: invoke the `arn-code-codebase-analyzer` agent with full analysis mode to generate pattern docs from scratch. Write the output to the Code patterns directory. Print: "Pattern documentation generated from scratch." Return.
    - If **at least one exists**: proceed to step 3.
 
-3. **Invoke the `arn-code-codebase-analyzer` agent** with full analysis mode. Pass the current Code patterns directory path and instruct the agent to analyze the full codebase for patterns, architecture, and testing conventions.
+3. **Invoke the `arn-code-codebase-analyzer` agent via the Task tool**, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback), with full analysis mode. Pass the current Code patterns directory path and instruct the agent to analyze the full codebase for patterns, architecture, and testing conventions.
 
 4. **Compare fresh analysis against stored pattern files.** Identify:
    - **New patterns** -- patterns found in the analysis that do not appear in stored docs

--- a/plugins/arn-code/skills/arn-code-execute-task/SKILL.md
+++ b/plugins/arn-code/skills/arn-code-execute-task/SKILL.md
@@ -96,7 +96,12 @@ Store the choice for the execution session.
 
    Note: Extract only the top-level fields (implicit Layer 1). Do NOT parse `#### Layer N:` subsections — multi-layer visual validation runs during `/arn-code-review-implementation`, not per-task.
 
-5. Spawn `arn-code-task-executor` via the Task tool with full context:
+5. **Determine the executor model.** First check the per-phase upgrade override:
+   - Read PROGRESS_TRACKER.json. Find the phase entry whose `implementation.taskId` matches the current task ID.
+   - If `phase.implementation.modelOverride` is non-null (e.g., `"opus"`), use that value as the `model` parameter for this dispatch. Skip the standard agent-models lookup. Emit a one-line status to the user: `Phase <N> (<phaseTitle>) executor model: <override> (upgraded — complex phase per pipeline.complex-phase-upgrade)`.
+   - If `phase.implementation.modelOverride` is null or the field is missing, fall through to the standard lookup: pass the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback).
+
+   Then spawn `arn-code-task-executor` via the Task tool with the determined model. Full context:
    - Task ID and full task description
    - Project name: `<PROJECT_NAME>`
    - Project folder path: `<plans-dir>/<PROJECT_NAME>/`
@@ -117,7 +122,7 @@ Store the choice for the execution session.
    - Report file path(s)
    - List of files created and modified
    - Visual capture directory path (if reported)
-2. Spawn `arn-code-task-reviewer` via the Task tool with:
+2. Spawn `arn-code-task-reviewer` via the Task tool, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
    - Task ID and full task description
    - Project name and folder path
    - INTRODUCTION.md path

--- a/plugins/arn-code/skills/arn-code-feature-spec/SKILL.md
+++ b/plugins/arn-code/skills/arn-code-feature-spec/SKILL.md
@@ -20,7 +20,7 @@ Develop a feature idea into a well-formed specification through iterative conver
 
 ## Step 0: Ensure Configuration
 
-Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/ensure-config.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/step-0-fast-path.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
 
 ## Workflow
 

--- a/plugins/arn-code/skills/arn-code-init/SKILL.md
+++ b/plugins/arn-code/skills/arn-code-init/SKILL.md
@@ -126,7 +126,7 @@ Check if the project uses Git, determine the code hosting platform, and identify
 
 ### Step 3A: Analyze Codebase Patterns
 
-Invoke the `arn-code-codebase-analyzer` agent with:
+Invoke the `arn-code-codebase-analyzer` agent via the Task tool, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - The detected project type (backend/frontend/fullstack — infer from the codebase)
 - The source root path (infer from project structure)
 - Any framework hint (infer from manifests/markers)
@@ -166,7 +166,7 @@ Be conversational, not rigid. Skip questions where the answer is obvious from pr
 
 ### Step 3B-2: Generate Recommended Patterns
 
-Invoke the `arn-code-pattern-architect` agent with all the technology choices gathered above.
+Invoke the `arn-code-pattern-architect` agent via the Task tool, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback), with all the technology choices gathered above.
 
 The agent returns recommended code patterns, testing patterns, and architecture — with concrete best-practice examples marked as "Recommended" rather than real file references.
 
@@ -295,6 +295,22 @@ Record the answer for the config write in Step 9.
 
 If `linting.md` does not exist (e.g., the analyzer failed earlier in Step 6, or this is a partial init), default the question's suggested value to `Skip` so the user is not blocked, and note in the config that linting will be re-checked on the next `arn-code-ensure-config` run.
 
+### Step 8c: Choose Model Profile for arn-code Agents
+
+Run the **Profile selection** procedure documented in `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/step-0-fast-path.md` under the "Model profile field" section. That procedure is the single source of truth for the prompt + write + copy + checksum flow — do NOT duplicate the AskUserQuestion or file-copy logic here.
+
+The procedure performs (in order):
+1. Cross-plugin default suggestion (read sibling plugin profile fields if present in the existing `## Arness` block)
+2. AskUserQuestion with title "Choose model profile for arn-code agents" and two options: `all-opus` (default unless a sibling chose `balanced`) and `balanced`
+3. Append `- **Code agent model profile:** <choice>` to the `## Arness` block
+4. `mkdir -p .arness/agent-models/` then copy `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-init/references/agent-models-presets/<choice>.md` to `.arness/agent-models/code.md`
+5. Compute SHA-256 and record it in `.arness/agent-models/.checksums.json` along with the profile name and version
+6. Inform the user with a one-line confirmation
+
+The field write in step 3 of the procedure is captured for the CLAUDE.md write in Step 9 of this init flow — write the chosen value to a holding variable and let Step 9 emit it inline with all other fields. The preset copy + checksum (steps 4-5 of the procedure) happen here regardless of when the CLAUDE.md write is performed.
+
+Record the chosen profile for the config write in Step 9.
+
 ---
 
 ### Step 9: Persist Configuration to CLAUDE.md
@@ -313,6 +329,7 @@ Write (or update) the `## Arness` section in the project's CLAUDE.md:
 - **Code patterns:** [chosen-pattern-docs-path]
 - **Docs directory:** [chosen-docs-path]
 - **Linting:** enabled | none | skip
+- **Code agent model profile:** all-opus | balanced | custom
 - **Git:** yes | no
 - **Platform:** github | bitbucket | none
 - **Issue tracker:** github | jira | none
@@ -406,7 +423,7 @@ Entered from Step 1 when the user chooses **Upgrade**. Diagnoses gaps using the 
 
 ### Step U1: Run Diagnostic
 
-Invoke the `arn-code-doctor` agent via the Task tool with:
+Invoke the `arn-code-doctor` agent via the Task tool, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - Description: "Comprehensive health check for arn-code-init upgrade. Check ALL categories: config fields, directories, template files, checksums, Git/Platform/Issue tracker state, platform labels, and pattern doc schema compliance. Use only Read/Glob/Grep and the allowed Bash commands (git status, git remote -v, gh auth status, gh label list, bkt --version, bkt auth status, ls). Do NOT run claude CLI commands."
 - Project root path
 - The parsed `## Arness` config content

--- a/plugins/arn-code/skills/arn-code-init/references/agent-models-presets/all-opus.md
+++ b/plugins/arn-code/skills/arn-code-init/references/agent-models-presets/all-opus.md
@@ -1,0 +1,22 @@
+# Profile: all-opus
+# Version: 1.1.0
+
+arn-code-architect: opus
+arn-code-batch-analyzer: opus
+arn-code-batch-pr-analyzer: opus
+arn-code-bug-fixer: opus
+arn-code-codebase-analyzer: opus
+arn-code-doctor: opus
+arn-code-drift-detector: opus
+arn-code-feature-planner: opus
+arn-code-investigator: opus
+arn-code-pattern-architect: opus
+arn-code-planner: opus
+arn-code-security-specialist: opus
+arn-code-simplify-applier: opus
+arn-code-simplify-reviewer: opus
+arn-code-sketch-builder: opus
+arn-code-task-executor: opus
+arn-code-task-reviewer: opus
+arn-code-test-specialist: opus
+arn-code-ux-specialist: opus

--- a/plugins/arn-code/skills/arn-code-init/references/agent-models-presets/balanced.md
+++ b/plugins/arn-code/skills/arn-code-init/references/agent-models-presets/balanced.md
@@ -1,0 +1,22 @@
+# Profile: balanced
+# Version: 1.1.0
+
+arn-code-architect: opus
+arn-code-batch-analyzer: opus
+arn-code-batch-pr-analyzer: opus
+arn-code-bug-fixer: opus
+arn-code-codebase-analyzer: sonnet
+arn-code-doctor: sonnet
+arn-code-drift-detector: sonnet
+arn-code-feature-planner: opus
+arn-code-investigator: opus
+arn-code-pattern-architect: opus
+arn-code-planner: opus
+arn-code-security-specialist: opus
+arn-code-simplify-applier: sonnet
+arn-code-simplify-reviewer: opus
+arn-code-sketch-builder: sonnet
+arn-code-task-executor: sonnet
+arn-code-task-reviewer: opus
+arn-code-test-specialist: sonnet
+arn-code-ux-specialist: sonnet

--- a/plugins/arn-code/skills/arn-code-pick-issue/SKILL.md
+++ b/plugins/arn-code/skills/arn-code-pick-issue/SKILL.md
@@ -237,7 +237,7 @@ After the user has reviewed the issue details and agent assessment, offer option
 
 For brand-new issues with no prior feature file or spec, there is nothing to drift against — skip directly to Step 7.
 
-When the gate applies, spawn the `arn-code-drift-detector` agent via the Task tool with the existing feature file (or sub-feature spec) as the input spec:
+When the gate applies, spawn the `arn-code-drift-detector` agent via the Task tool, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context (the existing feature file or sub-feature spec is the input spec):
 
 ```
 Verify whether the following feature file / spec still aligns with the current codebase.

--- a/plugins/arn-code/skills/arn-code-plan/SKILL.md
+++ b/plugins/arn-code/skills/arn-code-plan/SKILL.md
@@ -79,7 +79,7 @@ Then invoke `arn-code-codebase-analyzer` (existing codebase) or `arn-code-patter
 
 Specs may have been written days or weeks before being planned. The codebase moves in the meantime — files get renamed, modules refactored, frameworks swapped. Before invoking the planner, verify the spec's concrete references still hold against HEAD.
 
-Spawn the `arn-code-drift-detector` agent via the Task tool with this context:
+Spawn the `arn-code-drift-detector` agent via the Task tool, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 ```
 Verify whether the following specification still aligns with the current codebase.
@@ -118,7 +118,7 @@ The output file path is: `<plans-dir>/PLAN_PREVIEW_<spec-name>.md`
 
 **Check for existing PLAN_PREVIEW:** If a PLAN_PREVIEW file already exists at that path, inform the user: "A plan preview already exists for this spec: `<path>`. Would you like to regenerate it from scratch, or review the existing plan?" If review → skip to Step 5. If regenerate → proceed.
 
-Spawn the `arn-code-feature-planner` agent via the Task tool with this context:
+Spawn the `arn-code-feature-planner` agent via the Task tool, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 ```
 You are generating an implementation plan for the following specification.
@@ -157,19 +157,82 @@ Record the agent ID returned by the Task tool (needed for resume in Step 5b).
 After the planner agent completes:
 
 1. Read the generated plan from `<plans-dir>/PLAN_PREVIEW_<spec-name>.md`
-2. Present a structured summary to the user:
+2. Parse each phase's `**Complexity:**` and `**Complexity rationale:**` fields (added by the planner per `${CLAUDE_PLUGIN_ROOT}/agents/arn-code-feature-planner.md`'s Complexity Assessment section). If a phase is missing these fields (older plans), treat its complexity as `unknown` and skip the upgrade gate for it.
+3. Present a structured summary to the user:
    - **Spec:** the linked specification name
-   - **Phases:** list each phase with a 1-line description and key deliverables
+   - **Phases:** list each phase with a 1-line description, key deliverables, **and complexity rating** (e.g., `Phase 3: Dispatch Site Edits — 7 deliverables — complexity: complex`). Always show the rating, regardless of whether an upgrade gate fires.
    - **Dependencies:** which phases depend on which
    - **Total files:** approximate count of files to create/modify
    - **Testing:** whether testing phases are included
-3. Ask: **"Does this plan look right, or would you like to change anything?"**
+4. Ask: **"Does this plan look right, or would you like to change anything?"**
 
 **If the user approves** (e.g., "looks good", "approved", "yes", "proceed"):
-→ Go to Step 6.
+→ Go to **Step 5a (Complex Phase Upgrade Gate)** before Step 6.
 
 **If the user provides feedback** (e.g., "split phase 2 into two phases", "add error handling for X", "remove the caching component"):
 → Go to Step 5b.
+
+#### Step 5a: Complex Phase Upgrade Gate
+
+Before marking the plan approved, check whether the user should be offered an executor model upgrade for any complex phases.
+
+**Filter:** Build the list of phases with `**Complexity:** complex`. If empty, skip this step entirely and go to Step 6.
+
+**Profile detection:** Read the project's CLAUDE.md `## Arness` block for `Code agent model profile:`. Branch:
+- If the field is `all-opus`: skip this step silently (every agent is already on Opus, nothing to upgrade). Display brief status line: `Preference: complex phase upgrade silenced — profile is all-opus (no upgrade needed)`. Go to Step 6.
+- If the field is `balanced` or `custom`: continue.
+- If the field is missing or `.arness/agent-models/code.md` doesn't exist: treat as unknown and continue (run the gate — the user gets the choice).
+
+**Two-tier preference lookup** for `pipeline.complex-phase-upgrade` per `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/preferences-schema.md`:
+
+1. Read `.arness/workflow.local.yaml` — if file exists and key present, use that value (note source).
+2. Else read `~/.arness/workflow-preferences.yaml` — if file exists and key present, use that value (note source).
+3. Else treat as `null` (first encounter).
+
+Branch on the resolved value:
+
+- **`always`:** auto-mark every phase with complexity `complex` for `modelOverride: "opus"` in the in-memory plan structure (carried into save-plan). Display status line: `Preference: upgrading N complex phases to Opus executor (stored in <source>)`. Go to Step 6.
+- **`never`:** skip the gate silently. Go to Step 6.
+- **`ask`:** show the gate below. Do NOT show the remember-this follow-up afterward.
+- **`null` (first encounter):** show the gate below. After the user answers, show the remember-this follow-up.
+
+**Gate (shown when value is `ask`, `null`, or invalid):**
+
+Build a phase list for the prompt:
+```
+N phases are rated complex:
+  - Phase 2: <title> — <complexityRationale>
+  - Phase 3: <title> — <complexityRationale>
+  - Phase 5: <title> — <complexityRationale>
+```
+
+Ask (using `AskUserQuestion`):
+
+**"N phases are rated complex. Upgrade ALL of them to Opus for execution? (Reviewer dispatches stay on configured tier.)"**
+
+Options:
+1. **Yes, upgrade all complex phases** (Recommended for known-complex work) — mark every complex phase for `modelOverride: "opus"`
+2. **No, keep configured tier** — no override applied; phases run on the agent-models lookup result
+
+If **Yes**: mark every complex phase in the in-memory plan structure for `modelOverride: "opus"`. The override is persisted by `arn-code-save-plan` Step 5 into PROGRESS_TRACKER.json.
+If **No**: no override applied.
+
+**Follow-up (only when preference was null):** After the user answers the gate, ask:
+
+Ask (using `AskUserQuestion`):
+
+**"Should Arness remember this choice for future sessions?"**
+
+Options:
+1. **Yes, always upgrade complex phases** (saves `always` to preferences)
+2. **Yes, never upgrade complex phases** (saves `never` to preferences)
+3. **No, ask me each time**
+
+If **Yes (always)**: write `always` to `~/.arness/workflow-preferences.yaml` under `pipeline.complex-phase-upgrade`. Create `~/.arness/` directory and file if they do not exist. If file exists, read first, add or update the key under `pipeline:`, write back preserving all existing keys.
+If **Yes (never)**: write `never` to `~/.arness/workflow-preferences.yaml` under `pipeline.complex-phase-upgrade` (same write logic).
+If **No**: write `ask` to `~/.arness/workflow-preferences.yaml` under `pipeline.complex-phase-upgrade` (same write logic).
+
+After Step 5a completes (gate applied or skipped), go to Step 6.
 
 #### Step 5b: Iterate with Feedback
 
@@ -187,7 +250,7 @@ to the same file. Summarize what you changed.
 ```
 
 **If resume fails** (API error, agent ID no longer valid):
-Fall back to spawning a fresh `arn-code-feature-planner` agent with:
+Fall back to spawning a fresh `arn-code-feature-planner` agent via the Task tool, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 ```
 You are revising an existing implementation plan based on user feedback.

--- a/plugins/arn-code/skills/arn-code-report/SKILL.md
+++ b/plugins/arn-code/skills/arn-code-report/SKILL.md
@@ -75,7 +75,7 @@ If GitHub access is not available, offer an alternative: generate the diagnostic
 
 ### Step 4: Invoke arn-code-doctor
 
-Spawn the `arn-code-doctor` agent via the Task tool with:
+Spawn the `arn-code-doctor` agent via the Task tool, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - The user's description of the issue
 - Project root path
 - `## Arness` config content (or "not configured")

--- a/plugins/arn-code/skills/arn-code-save-plan/SKILL.md
+++ b/plugins/arn-code/skills/arn-code-save-plan/SKILL.md
@@ -190,6 +190,7 @@ Populate with:
 - One entry per phase in `phases[]`:
   - `phaseNumber`, `phaseTitle`, `planFile` from the phase plans
   - `implementation.status`: `"not_started"`, `implementation.taskId`: the implementation task number from TASKS.md for this phase, `implementation.reportFile`: `reports/IMPLEMENTATION_REPORT_PHASE_N.json`
+  - `implementation.modelOverride`: `"opus"` if the upstream `arn-code-plan` Step 5a or `arn-code-batch-planning` Step 3.5c marked this phase for upgrade (read from the plan structure or the in-memory upgrade list passed by the orchestrator), otherwise `null`. The upgrade decision is captured per-phase based on the phase's `**Complexity:** complex` rating combined with the user's gate answer per `pipeline.complex-phase-upgrade`. See `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/preferences-schema.md` "Complex Phase Upgrade" section for the full decision flow.
   - `testing.status`: `"not_started"` if the phase has a Testing section, or `"none"` if it does not. `testing.taskId`: the testing task number from TASKS.md (or `null` if no testing), `testing.reportFile`: `reports/TESTING_REPORT_PHASE_N.json`
   - `review.verdict`: empty string, `review.reviewCycles`: `0`, `review.reportFile`: `reports/TASK_REVIEW_TASK_N.json`
 

--- a/plugins/arn-code/skills/arn-code-save-plan/report-templates/default/PROJECT_PROGRESS_REPORT_TEMPLATE.json
+++ b/plugins/arn-code/skills/arn-code-save-plan/report-templates/default/PROJECT_PROGRESS_REPORT_TEMPLATE.json
@@ -13,7 +13,8 @@
         "status": "not_started | in_progress | completed | skipped",
         "taskId": null,
         "completedAt": "",
-        "reportFile": "reports/IMPLEMENTATION_REPORT_PHASE_1.json"
+        "reportFile": "reports/IMPLEMENTATION_REPORT_PHASE_1.json",
+        "modelOverride": null
       },
       "testing": {
         "status": "not_started | in_progress | completed | skipped | none",

--- a/plugins/arn-code/skills/arn-code-simplify/SKILL.md
+++ b/plugins/arn-code/skills/arn-code-simplify/SKILL.md
@@ -78,7 +78,7 @@ Hold this context for use throughout the workflow.
 
 > Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-simplify/references/review-prompts.md` for the three reviewer prompt templates and output format.
 
-Dispatch three Agent tool calls **in a single message** so they run in parallel:
+Dispatch three Agent tool calls **in a single message** so they run in parallel. Each call passes the model from `.arness/agent-models/code.md` (look up `arn-code-simplify-reviewer`) as the `model` parameter (see `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/step-0-fast-path.md` "Dispatch convention" for fallback behavior). The three reviewers share the same synthetic name — apply the multi-agent rule by passing the looked-up value to each call independently.
 
 1. **Code Reuse Reviewer** -- fill the review-prompts.md template with the file list and pattern documentation. Instruct the agent to focus on duplicated logic, missed utilities, and copy-paste patterns.
 
@@ -157,26 +157,64 @@ The user may also change individual finding statuses (e.g., "approve SIM-001 but
 
 ### Step 6: Apply Approved Simplifications
 
-For each approved finding, in dependency order (if finding B depends on finding A's changes, apply A first):
+The orchestrator pre-sorts the approved findings by dependency order (if finding B depends on finding A's changes, A comes first), then dispatches a single anonymous Agent call to perform the apply work. The model is configurable via the agent-models config.
 
-1. Apply the suggested fix.
+**Dispatch the applier as an anonymous Agent tool call**, passing the model from `.arness/agent-models/code.md` (look up `arn-code-simplify-applier`) as the `model` parameter (see `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/step-0-fast-path.md` "Dispatch convention" for fallback behavior). Do NOT add any tool restriction — the applier inherits `Edit`, `Write`, `Bash`, `Read`, `Grep`, `Glob` from the orchestrator's toolbelt by default, and needs all of them.
 
-2. Run targeted tests relevant to the modified files:
-   - Use the test command from the scope's context or from testing-patterns.md
-   - Only run tests covering the modified files, not the full suite
+**Applier prompt contents:**
 
-3. If tests pass: mark the finding as `"applied"`. Record in `applicationResults`.
+- The pre-sorted list of approved findings (each with `id`, `title`, `description`, `suggestedFix`, `filesAffected`, and `axis`)
+- The targeted-test command (from the scope's context or testing-patterns.md)
+- Paths to relevant pattern docs (code-patterns.md, testing-patterns.md) so the applier can reference them when self-healing
+- The exact instructions below:
 
-4. If tests fail: attempt self-healing.
-   - Fix the implementation issue that caused the failure.
-   - Re-run the targeted tests.
+```
+For each finding in the provided list, IN ORDER:
+
+1. Capture pre-state: `git diff --no-color HEAD > /tmp/pre-{findingId}.diff`
+2. Apply the suggested fix (Edit/Write the affected files).
+3. Run the targeted test command. Capture stdout+stderr.
+4. If tests pass: emit `[FINDING-{findingId}: applied]` to stdout. Record status `"applied"`. Continue to next finding.
+5. If tests fail: attempt self-healing.
+   - Re-read the test output to identify the failure cause.
+   - Make a fix attempt (Edit the file).
+   - Re-run the targeted test command.
    - Up to 3 self-heal attempts per finding.
+6. If tests still fail after 3 attempts: revert this finding's changes via `git apply -R /tmp/pre-{findingId}.diff` (or, if the diff is empty because no prior changes existed, run `git checkout -- {filesAffected}`). Emit `[FINDING-{findingId}: reverted - <reason>]` to stdout. Record status `"reverted"` with the failure reason and last test output. Continue to next finding.
+7. Always emit a per-finding status line so the user sees progress in the transcript.
 
-5. If tests still fail after 3 attempts: **revert** the changes for this specific finding. Mark as `"reverted"` with the failure reason. Record in `applicationResults` and `testVerification.revertedFindings`.
+After processing all findings, run ONE final targeted test pass to verify the cumulative state is consistent. Capture the result.
 
-6. Proceed to the next finding regardless of whether this one was reverted.
+RETURN — strictly as the final message — a JSON object with this exact schema (no other text):
 
-After all approved findings are processed, run one final targeted test pass to verify the cumulative changes are consistent.
+{
+  "applicationResults": [
+    {
+      "findingId": "SIM-001",
+      "status": "applied" | "reverted",
+      "attempts": <integer 1-4>,
+      "testOutput": "<last test command output, truncated to 2000 chars>",
+      "revertReason": "<reason if reverted, omitted if applied>"
+    }
+  ],
+  "finalTestResult": {
+    "passed": <boolean>,
+    "output": "<final test pass output, truncated to 2000 chars>"
+  }
+}
+
+If you crash or have to abort partway through, return the JSON with results for the findings you DID process — do not omit the JSON entirely. Mark unprocessed findings as `status: "pending"` so the orchestrator can surface the partial state.
+```
+
+**After the applier returns:**
+
+1. Parse the returned JSON. If parsing fails or the schema is incomplete, treat any missing finding as `status: "pending"` and add a warning to the report's `warnings` array: `"Applier returned malformed or partial results. <N> findings have unknown status."`
+2. Populate the report's `applicationResults` array directly from the applier's return.
+3. Populate `testVerification.revertedFindings` from any entries with `status: "reverted"`.
+4. Populate `testVerification.finalTestPassed` from `finalTestResult.passed`.
+5. Format a brief user-facing summary from the per-finding statuses for display (mirror the previous Step 7 summary shape).
+
+**Auto-all mode interaction:** Both interactive approval (Step 5) and `auto-all` mode reach this same Step 6 dispatch — the applier dispatch is identical in both paths. The only difference is whether Step 5 prompted the user or skipped the prompt.
 
 ---
 
@@ -235,4 +273,4 @@ Based on the scope context, offer the appropriate next step:
 - Each self-heal cycle gets at most 3 attempts before revert.
 - Per-simplification revert: a failed finding does not affect other successfully applied findings.
 - Never modify files outside the scope's file list without explicit user approval.
-- Anonymous Agent tool calls only -- no named agent files for reviewers.
+- Reviewer and applier dispatches use synthetic agent names for model-config lookup; no agent files are required.

--- a/plugins/arn-code/skills/arn-code-sketch/SKILL.md
+++ b/plugins/arn-code/skills/arn-code-sketch/SKILL.md
@@ -173,7 +173,7 @@ See the arn-code-sketch-builder agent Step 6 for the full schema including `comp
 
 ### Step 5: Spawn the Builder Agent
 
-Spawn the `arn-code-sketch-builder` agent with:
+Spawn the `arn-code-sketch-builder` agent via the Task tool, passing the model from `.arness/agent-models/code.md` as the `model` parameter (see `plugins/arn-code/skills/arn-code-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 --- SKETCH CONTEXT ---
 **Feature:** [feature name and description]

--- a/plugins/arn-code/skills/arn-code-standard/SKILL.md
+++ b/plugins/arn-code/skills/arn-code-standard/SKILL.md
@@ -22,7 +22,7 @@ This is an execution skill. It runs in normal conversation (NOT plan mode).
 
 ## Step 0: Ensure Configuration
 
-Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/ensure-config.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/step-0-fast-path.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
 
 ## Pipeline Position
 

--- a/plugins/arn-code/skills/arn-code-swift/SKILL.md
+++ b/plugins/arn-code/skills/arn-code-swift/SKILL.md
@@ -24,7 +24,7 @@ This is an execution skill. It runs in normal conversation (NOT plan mode).
 
 ## Step 0: Ensure Configuration
 
-Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/ensure-config.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/step-0-fast-path.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
 
 ## Pipeline Position
 

--- a/plugins/arn-code/skills/arn-implementing/SKILL.md
+++ b/plugins/arn-code/skills/arn-implementing/SKILL.md
@@ -21,7 +21,7 @@ This skill is a **sequencer and decision-gate handler**. It MUST NOT duplicate s
 
 ## Step 0: Ensure Configuration
 
-Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/ensure-config.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/step-0-fast-path.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
 
 After Step 0 completes, extract the following from `## Arness`:
 - **Plans directory** — for detecting structured plans and project folders

--- a/plugins/arn-code/skills/arn-planning/SKILL.md
+++ b/plugins/arn-code/skills/arn-planning/SKILL.md
@@ -23,7 +23,7 @@ This skill is a **sequencer and decision-gate handler**. It MUST NOT duplicate s
 
 ## Prerequisites: Ensure Configuration
 
-Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/ensure-config.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/step-0-fast-path.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
 
 After configuration is ensured, extract the following from `## Arness`:
 - **Plans directory** — for detecting plan previews and project folders

--- a/plugins/arn-code/skills/arn-reviewing-pr/SKILL.md
+++ b/plugins/arn-code/skills/arn-reviewing-pr/SKILL.md
@@ -19,7 +19,7 @@ This skill is a **thin orchestration wrapper**. It MUST NOT duplicate `arn-code-
 
 ## Step 0: Ensure Configuration
 
-Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/ensure-config.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/step-0-fast-path.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
 
 After Step 0 completes, extract the following from `## Arness`:
 - **Platform** — determines if PR operations are available (`github`, `bitbucket`, or `none`)

--- a/plugins/arn-code/skills/arn-shipping/SKILL.md
+++ b/plugins/arn-code/skills/arn-shipping/SKILL.md
@@ -20,7 +20,7 @@ This skill is a **thin orchestration wrapper**. It MUST NOT duplicate `arn-code-
 
 ## Step 0: Ensure Configuration
 
-Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/ensure-config.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-ensure-config/references/step-0-fast-path.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Code fields before proceeding.
 
 ## Workflow
 

--- a/plugins/arn-infra/skills/arn-infra-assess/SKILL.md
+++ b/plugins/arn-infra/skills/arn-infra-assess/SKILL.md
@@ -22,7 +22,7 @@ This skill serves two primary use cases:
 
 ## Step 0: Ensure Configuration
 
-Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-ensure-config/references/ensure-config.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Infra fields before proceeding.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-ensure-config/references/step-0-fast-path.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Infra fields before proceeding.
 
 After Step 0 completes, read `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-ensure-config/references/experience-derivation.md` and derive the user's infrastructure experience level from their profile.
 
@@ -74,7 +74,7 @@ Resolve the application project based on topology:
 
 ### Step 3: Full Application Analysis
 
-Invoke the `arn-infra-request-analyzer` agent in Mode B (full application analysis). Pass the loaded codebase patterns, architecture content, deferred backlog (if any), and infrastructure config fields as structured context.
+Invoke the `arn-infra-request-analyzer` agent via the Task tool in Mode B (full application analysis), passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Pass the loaded codebase patterns, architecture content, deferred backlog (if any), and infrastructure config fields as structured context.
 
 > Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-assess/references/agent-invocation-guide.md` for the exact prompt template and expected return format.
 

--- a/plugins/arn-infra/skills/arn-infra-assess/references/agent-invocation-guide.md
+++ b/plugins/arn-infra/skills/arn-infra-assess/references/agent-invocation-guide.md
@@ -6,7 +6,7 @@ Reference for agent invocation during the arn-infra-assess workflow.
 
 ## arn-infra-request-analyzer (Mode B: Full Application Analysis)
 
-Invoke the `arn-infra-request-analyzer` agent in Mode B with the following structured prompt:
+Invoke the `arn-infra-request-analyzer` agent via the Task tool in Mode B, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback), with the following structured prompt:
 
 --- APPLICATION CONTEXT ---
 [codebase patterns content]

--- a/plugins/arn-infra/skills/arn-infra-change-plan/SKILL.md
+++ b/plugins/arn-infra/skills/arn-infra-change-plan/SKILL.md
@@ -89,7 +89,7 @@ Options:
 
 If **Review**, skip to Step 4. If **Regenerate**, proceed.
 
-Invoke the `arn-infra-change-planner` agent via the Task tool with:
+Invoke the `arn-infra-change-planner` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 ```text
 You are generating a phased infrastructure implementation plan for the following change specification.
@@ -167,7 +167,7 @@ Go to Step 4b.
 
 #### Step 4b: Iterate with Feedback
 
-Invoke a fresh `arn-infra-change-planner` agent via the Task tool with the current plan and user feedback:
+Invoke a fresh `arn-infra-change-planner` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context (the current plan and user feedback):
 
 ```text
 You are revising an existing infrastructure implementation plan based on user feedback.

--- a/plugins/arn-infra/skills/arn-infra-change-spec/SKILL.md
+++ b/plugins/arn-infra/skills/arn-infra-change-spec/SKILL.md
@@ -134,7 +134,7 @@ Using the change description (from Step 2a or 2b), perform initial analysis:
 
 **If application context is available** (the change is driven by an application feature, or cross-project artifacts exist):
 
-Invoke the `arn-infra-request-analyzer` agent via the Task tool with:
+Invoke the `arn-infra-request-analyzer` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 ```text
 --- CHANGE CONTEXT ---

--- a/plugins/arn-infra/skills/arn-infra-containerize/SKILL.md
+++ b/plugins/arn-infra/skills/arn-infra-containerize/SKILL.md
@@ -115,7 +115,7 @@ If multi-service or compose is needed:
 
 > Read the local override or plugin default for `compose-patterns.md`.
 
-Invoke the `arn-infra-specialist` agent via the Task tool with:
+Invoke the `arn-infra-specialist` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 --- APPLICATION CONTEXT ---
 Technology stack: [language, framework, runtime version]
@@ -167,7 +167,7 @@ Load the security checklist:
 
 > Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-containerize/references/container-security-checklist.md` for container security requirements.
 
-Invoke the `arn-infra-security-auditor` agent via the Task tool with:
+Invoke the `arn-infra-security-auditor` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 --- FILES TO AUDIT ---
 [generated Dockerfile content(s)]

--- a/plugins/arn-infra/skills/arn-infra-define/SKILL.md
+++ b/plugins/arn-infra/skills/arn-infra-define/SKILL.md
@@ -157,7 +157,7 @@ Options:
 
 ### Step 5: Invoke Specialist Agent for IaC Generation
 
-Invoke the `arn-infra-specialist` agent via the Task tool with:
+Invoke the `arn-infra-specialist` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 --- APPLICATION CONTEXT ---
 [Application architecture from Step 3, or triage brief content from Step 2]
@@ -230,9 +230,9 @@ Run the validation ladder up to the configured validation ceiling. Each level bu
 
 **Level 2 -- Security Scan and Cost Estimation (if ceiling >= 2):**
 - Run `checkov` or `trivy` on the generated IaC if available
-- Invoke the `arn-infra-cost-analyst` agent for cost estimation:
+- Invoke the `arn-infra-cost-analyst` agent via the Task tool for cost estimation, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback):
 
-  Invoke the `arn-infra-cost-analyst` agent via the Task tool with:
+  Invoke the `arn-infra-cost-analyst` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
   --- INFRASTRUCTURE CODE ---
   [generated IaC files]

--- a/plugins/arn-infra/skills/arn-infra-ensure-config/SKILL.md
+++ b/plugins/arn-infra/skills/arn-infra-ensure-config/SKILL.md
@@ -5,16 +5,18 @@ description: >-
   "arn-infra-ensure-config", "verify arn infra setup", or wants to verify that Arness Infra
   configuration is present for the current project. This skill is primarily consumed
   as a reference by entry-point skills (arn-infra-wizard, arn-infra-assess) which
-  read the ensure-config reference as Step 0 before proceeding with their workflow.
-version: 1.0.0
+  read the `references/step-0-fast-path.md` reference as Step 0 before proceeding with their workflow.
+version: 1.1.0
 ---
 
 # Arness Infra Ensure Config
 
-Verify and establish Arness Infra configuration for the current project. This skill guarantees that a valid user profile and `## Arness` section exist before any Arness Infra workflow proceeds. It runs automatically as Step 0 of all entry-point skills.
+Verify and establish Arness Infra configuration for the current project. This skill guarantees that a valid user profile and `## Arness` section exist before any Arness Infra workflow proceeds. It runs automatically as Step 0 of all entry-point skills via a hash-based fast-path cache.
 
-When invoked directly, it performs the same checks and setup as when called by an entry-point skill.
+**Entry points should NOT read this SKILL.md directly.** They should read `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-ensure-config/references/step-0-fast-path.md`, which runs the cache-check shell script and only falls through to the full validation when needed. This indirection is what saves ~95% of ensure-config token cost.
+
+When invoked DIRECTLY (rare — typically via `/arn-infra-ensure-config`), this skill bypasses the cache and runs the full validation flow.
 
 ## Workflow
 
-Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-ensure-config/references/ensure-config.md` and follow its instructions.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-ensure-config/references/ensure-config.md` and follow its instructions (Layers 1–3, then Layer 4 cache write).

--- a/plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md
+++ b/plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md
@@ -6,66 +6,6 @@ Follow the layers below in order. Each layer has a fast path (skip when already 
 
 ---
 
-## Layer 0: Migration Check (Nova to Arness)
-
-This layer runs before everything else. It silently migrates legacy Nova artifacts to the Arness naming convention. All steps are idempotent — safe to run multiple times. No user prompts; log-only.
-
-### 0a. Project Directory
-
-Check via Bash:
-```bash
-test -d .nova && echo "OLD_EXISTS" || echo "OLD_MISSING"
-test -d .arness && echo "NEW_EXISTS" || echo "NEW_MISSING"
-```
-
-- If `.nova/` exists AND `.arness/` does NOT exist: run `mv .nova .arness`. Log: "Migrated project directory: .nova/ -> .arness/"
-- If both exist: skip (safety). Log: "Both .nova/ and .arness/ exist — skipping directory migration"
-- Otherwise: no action needed.
-
-### 0b. CLAUDE.md Config Section
-
-Read CLAUDE.md (if it exists) and check for `## Nova` and `## Arness` headers.
-
-- If `## Nova` exists AND `## Arness` does NOT exist: replace `## Nova` with `## Arness` in CLAUDE.md. Log: "Migrated config section: ## Nova -> ## Arness"
-- If both exist: skip (safety). Log: "Both ## Nova and ## Arness sections exist — skipping section migration"
-- Otherwise: no action needed.
-
-### 0c. User Home Directory
-
-Check via Bash:
-```bash
-test -d ~/.nova && echo "OLD_EXISTS" || echo "OLD_MISSING"
-test -d ~/.arness && echo "NEW_EXISTS" || echo "NEW_MISSING"
-```
-
-- If `~/.nova/` exists AND `~/.arness/` does NOT exist: run `mv ~/.nova ~/.arness`. Log: "Migrated user directory: ~/.nova/ -> ~/.arness/"
-- If both exist: skip (safety). Log: "Both ~/.nova/ and ~/.arness/ exist — skipping user directory migration"
-- Otherwise: no action needed.
-
-### 0d. Gitignore
-
-Read `.gitignore` (if it exists) and check for `.nova/*.local.yaml`.
-
-- If `.gitignore` contains `.nova/*.local.yaml` but NOT `.arness/*.local.yaml`: replace `.nova/*.local.yaml` with `.arness/*.local.yaml`. Log: "Updated .gitignore: .nova/*.local.yaml -> .arness/*.local.yaml"
-- If both patterns exist: skip (safety).
-- Otherwise: no action needed.
-
-### 0e. Profile Reference
-
-Check via Bash:
-```bash
-test -f .claude/nova-profile.local.md && echo "OLD_EXISTS" || echo "OLD_MISSING"
-test -f .claude/arness-profile.local.md && echo "NEW_EXISTS" || echo "NEW_MISSING"
-```
-
-- If `.claude/nova-profile.local.md` exists AND `.claude/arness-profile.local.md` does NOT exist: run `mv .claude/nova-profile.local.md .claude/arness-profile.local.md`. Log: "Migrated profile: nova-profile.local.md -> arness-profile.local.md"
-- If both exist: skip (safety).
-- Otherwise: no action needed.
-
-After all migration steps complete (or are skipped), proceed to Layer 1.
-
----
-
 ## Layer 1: Profile Check (Welcome & Profile)
 
 ### 1a. Check for Existing Profile
@@ -159,11 +99,14 @@ technology_preferences:
 expertise_aware: true | false
 ```
 
-3. Verify `.claude/*.local.md` and `.claude/settings.local.json` are in the project's `.gitignore`:
+3. Verify `.claude/*.local.md`, `.claude/settings.local.json`, and `.arness/*.local.*` are in the project's `.gitignore`:
    - Read `.gitignore` in the project root
-   - If `.gitignore` does not exist, create it with `.claude/settings.local.json` and `.claude/*.local.md` as entries
-   - If `.gitignore` exists but does not contain `.claude/*.local.md`, append `.claude/settings.local.json` and `.claude/*.local.md` on new lines
+   - If `.gitignore` does not exist, create it with `.claude/settings.local.json`, `.claude/*.local.md`, and `.arness/*.local.*` as entries
+   - If `.gitignore` exists but does not contain `.claude/*.local.md`, append `.claude/*.local.md` on a new line
+   - If `.gitignore` exists but does not contain `.claude/settings.local.json`, append `.claude/settings.local.json` on a new line
+   - If `.gitignore` exists but does not contain `.arness/*.local.*` (or the equivalent `.arness/*.local.yaml` legacy pattern), append `.arness/*.local.*` on a new line
    - **Important:** Do NOT gitignore the entire `.claude/` directory — `.claude/settings.json` and other project-level Claude Code settings should remain committable for team sharing.
+   - **Important:** Do NOT gitignore the entire `.arness/` directory — `.arness/preferences.yaml` (team technology preferences) and other Arness project files must remain committable.
 4. Optionally create `.claude/arness-profile.local.md` if the user wants project-specific adjustments
 
 Display a closing message:
@@ -257,15 +200,17 @@ Fields to write:
 - CI/CD platform
 - Reference overrides, Reference version, Reference updates
 
+**Do NOT default the `Infra agent model profile:` field here either.** Leave it absent so Layer 2c routes to the **Profile selection** procedure (see "Model profile field" section below) on the next ensure-config invocation. This guarantees the user is asked rather than silently set to `all-opus`. The corresponding `.arness/agent-models/infra.md` file is created by the Profile selection procedure, not by this fast path.
+
 **Create directories:**
 
 Run via Bash: `mkdir -p` for each configured directory (infra-plans, infra-specs, infra-docs, infra-templates).
 
 ### 2c. If `## Arness` Exists But Arness Infra Fields Are Missing
 
-Check for the presence of Arness Infra fields: `Infra plans directory`, `Infra specs directory`, `Infra docs directory`, `Infra report templates`, `Infra template path`.
+Check for the presence of Arness Infra fields: `Infra plans directory`, `Infra specs directory`, `Infra docs directory`, `Infra report templates`, `Infra template path`, `Infra agent model profile`.
 
-If any are missing:
+If any directory-style fields are missing (`Infra plans directory`, `Infra specs directory`, `Infra docs directory`, `Infra report templates`, `Infra template path`):
 
 1. Check the `Folder preference` field in the existing `## Arness` section.
 2. If `Folder preference: defaults` — silently add missing Infra fields with default values. Create directories via `mkdir -p`.
@@ -273,9 +218,30 @@ If any are missing:
 4. If no `Folder preference` field exists — add it with value `defaults` and silently add missing fields.
 5. **Preserve all existing fields** from other plugins (Code fields, Spark fields) per the CLAUDE.md Config Section pattern.
 
+If the `Infra agent model profile:` field is missing (separate logic — this field requires a real choice and downstream artifact copy):
+
+1. Run the **Profile selection** procedure documented in the "Model profile field" section below. The procedure handles the AskUserQuestion prompt, writes the field to the `## Arness` block, copies the chosen preset to `.arness/agent-models/infra.md`, and records the SHA-256 checksum.
+
+If the `Infra agent model profile:` field is **present** (consistency check — runs whether or not directory fields are also missing):
+
+1. **If value is `all-opus` or `balanced`:**
+   a. Compute the SHA-256 checksum of `.arness/agent-models/infra.md` and compare it to the recorded checksum in `.arness/agent-models/.checksums.json`.
+   b. If checksums **differ** (user edited the file): flip the field value in `## Arness` from its current value to `custom` and inform the user with a one-line message: `"Detected your edits to .arness/agent-models/infra.md — set profile to 'custom' so future updates won't overwrite your changes."` Do NOT overwrite the user's edits; do NOT recompute the checksum (the `custom` profile means "user-managed").
+   c. If checksums match: read the `# Version:` header from `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-init/references/agent-models-presets/<value>.md` (the upstream preset) and compare to the `# Version:` header recorded in `.arness/agent-models/infra.md`. If they differ, apply the project's `Template updates:` policy (reuse the procedure in `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-save-plan/references/template-versioning.md` — Infra reuses Arness Code's template-versioning machinery):
+      - `auto`: copy the new preset, regenerate the checksum, inform the user "Refreshed `.arness/agent-models/infra.md` from preset `<value>` v<old>→v<new>."
+      - `ask`: prompt the user; on accept, copy + regenerate; on decline, leave file alone and skip until the user re-runs.
+      - `manual`: do nothing this run.
+
+2. **If value is `custom`:**
+   a. Read the canonical agent list from `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-init/references/agent-models-presets/all-opus.md` (every entry of the form `<agent-name>: <model>`).
+   b. Read the user's `.arness/agent-models/infra.md` and collect the agent names present.
+   c. For any agent in the canonical list that is NOT present in the user's file, surface as an info-level diagnostic: `"Note: .arness/agent-models/infra.md is missing entries for: <comma-separated agent list>. Add them or run with 'all-opus'/'balanced' profile to refresh."` This is informational only — do not block the workflow.
+
+3. **If value is anything else** (legacy/typo): treat as missing — run the Profile selection procedure to repair.
+
 ### 2d. If `## Arness` Exists and All Infra Fields Are Present
 
-**Fast path.** No action needed. Proceed to Layer 3.
+**Fast path.** Verify against the canonical Infra fields list at the top of section 2c — every field on that list (including `Infra agent model profile`) must be present. If `Infra agent model profile` is present, also run the checksum/version/custom-diagnostic checks documented in section 2c (they are cheap and idempotent). If all checks pass, no action needed; proceed to Layer 3.
 
 ---
 
@@ -302,6 +268,70 @@ No label creation needed. Jira labels are implicit (created on first use by Jira
 
 ---
 
+## Layer 4: Cache Write
+
+After Layers 1–3 complete successfully, write the validation cache so future ensure-config invocations can fast-path via `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-ensure-config/scripts/cache-check.sh`. This is the final step of the validation flow.
+
+### Why a cache?
+
+Entry-point skills invoke ensure-config as Step 0 on every workflow trigger (~30 trigger points across the plugin). Re-running the full Layers 1–3 flow on every invocation costs ~2k tokens even when nothing has changed. The cache lets the cache-check shell script (zero model tokens) verify validity in milliseconds; on hit, the entry-point skips reading this references file entirely (per the procedure in `references/step-0-fast-path.md`).
+
+### Cache file location
+
+`.arness/arn-infra-ensure-config.local.json` (project-local, gitignored via the `.arness/*.local.*` pattern from Layer 1c).
+
+### Cache schema
+
+```json
+{
+  "schemaVersion": 1,
+  "validatedAt": "2026-05-10T12:34:56Z",
+  "pluginVersion": "2.4.0",
+  "fingerprints": {
+    "claudeMdArnessSection": "<sha256 of the ## Arness block content>",
+    "agentModelsCodeMd": "<sha256 of .arness/agent-models/infra.md, or 'MISSING'>",
+    "agentModelsChecksums": "<sha256 of .arness/agent-models/.checksums.json, or 'MISSING'>",
+    "templatesChecksums": "<sha256 of .arness/templates/.checksums.json, or 'MISSING'>",
+    "userProfile": "<sha256 of ~/.arness/user-profile.yaml, or 'MISSING'>",
+    "profileOverride": "<sha256 of .claude/arness-profile.local.md, or 'MISSING'>",
+    "gitignoreContent": "<sha256 of .gitignore, or 'MISSING'>"
+  },
+  "validationStatus": "pass"
+}
+```
+
+(Note: the fingerprint key remains `agentModelsCodeMd` for cross-plugin schema consistency, but its value hashes the infra-specific file `.arness/agent-models/infra.md`.)
+
+### Write procedure
+
+1. **Compute the 7 fingerprints** using `sha256sum` (Linux + Git Bash) || `shasum -a 256` (Mac BSD). For the `claudeMdArnessSection` hash, extract the `## Arness` block via `awk '/^## Arness$/{flag=1;next} /^## /{flag=0} flag' CLAUDE.md` then pipe to the hasher. For each file fingerprint: if the file does not exist, use the literal string `MISSING` instead of computing a hash.
+
+2. **Read plugin version** from `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json` if present (legacy), else from the marketplace's `marketplace.json` entry for `arn-infra`. Use the empty string if neither is resolvable.
+
+3. **Construct the JSON object** with the schema above. `validatedAt` is the current ISO 8601 UTC timestamp. `validationStatus` is `"pass"` (only written on successful Layers 1–3).
+
+4. **Write atomically** using a project-local temp file (NOT `/tmp/` — Windows compat):
+
+   ```bash
+   <json content> > .arness/arn-infra-ensure-config.local.json.tmp
+   mv .arness/arn-infra-ensure-config.local.json.tmp .arness/arn-infra-ensure-config.local.json
+   ```
+
+   The `mv` is atomic on POSIX filesystems (Linux ext4, Mac APFS, Windows NTFS via Git Bash).
+
+5. **Verify** by reading the file back and confirming valid JSON. If the verify fails, surface as a warning but do not block — the next invocation will simply cache-miss.
+
+### When the cache invalidates
+
+- `pluginVersion` differs from current (plugin upgrade)
+- `schemaVersion` differs from current (cache schema bump — silently invalidates)
+- Any of the 7 fingerprints differs from current state
+- GitHub `arness-*` label count != 7 (when Platform=github and `gh` CLI available — checked inline in `cache-check.sh`, not stored in the JSON)
+
+All invalidation paths trigger a cache miss, which causes the entry-point to read the full ensure-config.md and re-run Layers 1–3 — at the end of which this Layer 4 step writes a new cache.
+
+---
+
 ## Important Rules
 
 1. **Never hard-block.** If auto-detection fails for a non-critical field (Platform, Issue tracker), default gracefully (`none`). Only the profile welcome flow is mandatory on first invocation.
@@ -313,3 +343,95 @@ No label creation needed. Jira labels are implicit (created on first use by Jira
 7. **Profile data is non-sensitive** (role, technology preferences — no credentials or secrets). The `.claude/*.local.md` gitignore pattern protects against accidental commits of the project-level override while keeping `.claude/settings.json` committable for team sharing.
 8. **Folder preference coordination:** When setting `Folder preference`, this value is shared across all three plugins. If another plugin already set it, respect that value.
 9. **Backward compatibility:** If `Experience level` exists in `## Arness` and no user profile exists, the experience-derivation.md reference documents how to use the legacy value. Once a profile is created, the profile takes precedence.
+
+---
+
+## Model profile field
+
+The `Infra agent model profile` field controls which Claude model each Arness Infra agent is dispatched on. It mirrors the structure of the Linting field flow used by Arness Code and reuses the same checksum + version-update machinery as report templates.
+
+### Field summary
+
+| Property | Value |
+|----------|-------|
+| Field name | `Infra agent model profile` |
+| Valid values | `all-opus` \| `balanced` \| `custom` |
+| Default on init | `all-opus` (preserves prior behavior) |
+| Where the choice lives | The field in `## Arness` records the user's choice; the actual model-per-agent map lives at `.arness/agent-models/infra.md`. |
+| Update policy | Reuses the project's `Template updates:` field (`ask` \| `auto` \| `manual`). If `Template updates:` is not present (Infra-only project), default to `ask`. |
+| Drift detection | SHA-256 checksum of `.arness/agent-models/infra.md` compared to the recorded checksum. Mismatch flips the field to `custom`. |
+| Custom diagnostic | When value is `custom`, missing-agent entries (against the canonical `all-opus.md` agent list) are surfaced as info-level diagnostics. |
+| User example | The arness repo's own `## Arness` block uses `Template path: .arness/templates`, `Template version: 2.3.0`, `Template updates: ask`. The model-profile field is appended in the same `- **Field name:** value` style. |
+
+### Profile selection procedure
+
+This procedure is the single source of truth for the prompt + write + copy + checksum flow. It is invoked from two places:
+- `arn-infra-init` ("Choose model profile" step), and
+- `arn-infra-ensure-config` Layer 2c (when the field is missing).
+
+Both call sites must read this section and follow it verbatim — do NOT duplicate the AskUserQuestion + write + copy + checksum logic at the call sites.
+
+**Steps:**
+
+1. **Cross-plugin default suggestion.** Before asking, read the project's CLAUDE.md `## Arness` block. If a sibling plugin's profile field (`Code agent model profile:` or `Spark agent model profile:`) is set to `all-opus` or `balanced`, suggest that value as the default in the AskUserQuestion options ordering (the recommended/default option goes first, with `(Recommended)` appended). If both siblings are set to different values, prefer the most recently written field; if neither is set, the default is `all-opus`.
+
+2. **Ask the user.** Ask (using `AskUserQuestion`):
+
+   > **Choose model profile for arn-infra agents**
+   > 1. **all-opus (Recommended)** — Every agent uses Opus. Maximum quality, maximum cost. (Current behavior.)
+   > 2. **balanced** — Opus for heavy reasoning, Sonnet for operational work. Lower cost, similar quality on routine tasks.
+
+   The label `(Recommended)` is appended to the suggested default (which may be `balanced` if a sibling plugin chose `balanced`). The recommended option appears first in the option list.
+
+3. **Write the field.** Append `- **Infra agent model profile:** <choice>` to the `## Arness` block in CLAUDE.md, using the existing field-write idiom (preserve all other fields, replace the single field if it already exists).
+
+4. **Copy the preset.** Create `.arness/agent-models/` if it does not exist (`mkdir -p .arness/agent-models`). Copy `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-init/references/agent-models-presets/<choice>.md` to `.arness/agent-models/infra.md`.
+
+5. **Record the checksum.** Compute the SHA-256 checksum of the copied file via Bash:
+   ```bash
+   sha256sum .arness/agent-models/infra.md 2>/dev/null || shasum -a 256 .arness/agent-models/infra.md
+   ```
+   Read or create `.arness/agent-models/.checksums.json`. Add or update the entry for `infra.md`:
+   ```json
+   {
+     "infra.md": {
+       "sha256": "<hex digest>",
+       "profile": "<choice>",
+       "version": "<version from the preset's # Version: header>"
+     }
+   }
+   ```
+   Preserve any sibling entries (`code.md`, `spark.md`) already present in `.checksums.json` — those belong to the other plugins and are managed by their own ensure-config flows.
+
+6. **Inform the user** with a one-line confirmation: `"Set Infra agent model profile to <choice>. Wrote .arness/agent-models/infra.md (sha256: <first-8-chars>...)."`
+
+### Drift detection (Layer 2c integration)
+
+Layer 2c runs the following whenever the field is present:
+
+1. **Checksum check.** Compute the current sha256 of `.arness/agent-models/infra.md` and compare to the recorded checksum in `.arness/agent-models/.checksums.json`. If they differ, flip the field to `custom` (one-line user message; do NOT overwrite the user's file).
+2. **Version check** (only when value is `all-opus` or `balanced` and checksums match): compare the `# Version:` header in the user's `.arness/agent-models/infra.md` against the upstream preset at `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-init/references/agent-models-presets/<value>.md`. On mismatch, apply the `Template updates:` policy (reuse `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-save-plan/references/template-versioning.md`).
+3. **Custom diagnostic** (only when value is `custom`): read the canonical agent list from `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-init/references/agent-models-presets/all-opus.md` and surface info-level diagnostics for any canonical agent missing from the user's file.
+
+---
+
+## Dispatch convention (agent model lookup)
+
+Every skill in this plugin that dispatches a subagent via the Task tool consults a per-plugin model profile to decide which model the agent runs on. The profile lives at `.arness/agent-models/infra.md` (project-relative, NOT plugin-relative — this path is project-rooted while plugin assets use `${CLAUDE_PLUGIN_ROOT}` per Pattern 8 in INTRODUCTION.md). The file is created during init and is one of the presets shipped under `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-init/references/agent-models-presets/`.
+
+### Lookup procedure (apply at every dispatch site)
+
+1. **Read `.arness/agent-models/infra.md`** (project-relative).
+2. **If the file is missing or unparseable:** omit the `model:` parameter when invoking the Task tool. The agent's frontmatter default (`opus`) applies. Do not surface an error — fallback is silent.
+3. **Look up the agent's name** (e.g., `arn-infra-specialist`, `arn-infra-change-planner`) in the file's mapping.
+4. **If the agent name is found:** pass the mapped value (e.g., `opus`, `sonnet`, `haiku`) as the Task tool's `model` parameter. This overrides the agent's `model:` frontmatter.
+5. **If the agent name is NOT found in the file:** omit the `model:` parameter — frontmatter fallback applies. This keeps user-edited `custom` profiles forward-compatible: agents added to the plugin after the user customized their profile still run on their frontmatter default (`opus`) until the user adds them to the file.
+6. **Multi-agent parallel dispatches:** apply the lookup to each agent independently. A single instruction that spawns three agents in parallel produces three independent lookups, each potentially passing a different `model:` value.
+7. **Resume-mode dispatches** (calls that pass an existing agent ID via the Task tool's `resume` parameter): do NOT consult the profile. Resume calls inherit the model from the original invocation. Dispatch sites that resume an existing agent do not include the model-lookup phrasing.
+
+### Why this design
+
+- **Native Task tool support.** The Task tool's `model:` parameter takes precedence over agent frontmatter (Pattern 2 in INTRODUCTION.md). No wrapper or shim is needed.
+- **Self-documenting.** Every dispatch site explicitly references this convention, so the lookup behavior is visible at the point of dispatch rather than buried in a global default. A static grep for `via the Task tool` confirms coverage.
+- **Graceful degradation.** Missing file, missing agent entry, and unparseable content all fall back to frontmatter — there is no failure mode where dispatch hangs or errors on a config issue.
+- **Single source of truth.** `.arness/agent-models/infra.md` is the only place a user edits to change behavior across all arn-infra dispatches. The file is template-managed (Pattern 6) so version bumps, drift detection, and the `Template updates: ask | auto | manual` policy all apply.

--- a/plugins/arn-infra/skills/arn-infra-ensure-config/references/step-0-fast-path.md
+++ b/plugins/arn-infra/skills/arn-infra-ensure-config/references/step-0-fast-path.md
@@ -1,0 +1,25 @@
+# Arness Infra Ensure-Config — Step 0 Fast-Path
+
+This is the **first read** for entry-point skills' Step 0. It runs a shell-only cache check; if the cache is valid, the entry-point can skip reading the full `references/ensure-config.md`. On cache miss, falls through to the full validation flow.
+
+## Procedure
+
+1. **Run the cache check** via Bash:
+
+   ```
+   bash ${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-ensure-config/scripts/cache-check.sh
+   ```
+
+2. **If exit 0 (cache hit):**
+   - Emit a one-line status to the user: `Ensure-config: cache valid (arn-infra, last validated <duration> ago)`. Read the `validatedAt` timestamp from `.arness/arn-infra-ensure-config.local.json` to format the duration; if reading fails, just say "cache valid".
+   - Return immediately. The entry-point skill's own workflow proceeds with no further config work.
+   - **Do NOT read `references/ensure-config.md`** — that is the whole point of the fast path.
+
+3. **If exit non-zero (cache miss):**
+   - The script's stderr output includes the reason (e.g., `cache miss: pluginVersion changed`, `cache miss: fingerprint claudeMdArnessSection changed`). Surface it as an info-level note: `Ensure-config: cache miss (<reason>) — running full validation.`
+   - **Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-ensure-config/references/ensure-config.md`** and follow ALL its instructions.
+   - At the end of successful validation, the ensure-config.md flow's "Cache Write" step writes the new `.arness/arn-infra-ensure-config.local.json` per the cache schema documented inline there.
+
+## Cross-platform notes
+
+The cache-check script works on Linux, Mac, and Windows-via-Git-Bash. It requires `bash`, `sha256sum` or `shasum`, `awk`, `grep`, `cat`, and `jq`. The `gh` CLI is optional (used only for GitHub label count verification). If any required tool is missing, the script exits non-zero and full validation runs as the fallback.

--- a/plugins/arn-infra/skills/arn-infra-ensure-config/scripts/cache-check.sh
+++ b/plugins/arn-infra/skills/arn-infra-ensure-config/scripts/cache-check.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# arn-infra-ensure-config cache-check.sh
+#
+# Returns exit 0 when the cache at .arness/arn-infra-ensure-config.local.json
+# is valid (all fingerprints match current state). Returns non-zero with a
+# stderr reason on miss.
+#
+# Cross-platform: works on Linux, Mac, and Windows-via-Git-Bash.
+# Required tools: bash, sha256sum or shasum, awk, grep, mv, cat, jq.
+# Optional tool: gh (only used for GitHub label count check).
+
+set -u
+
+PLUGIN_NAME="arn-infra"
+SHORT_NAME="infra"
+SCHEMA_VERSION=1
+EXPECTED_LABELS_COUNT=7
+CACHE_FILE=".arness/${PLUGIN_NAME}-ensure-config.local.json"
+
+# --- Helper: fail fast with reason ---
+miss() {
+  echo "cache miss: $1" >&2
+  exit 1
+}
+
+# --- Helper: cross-platform SHA-256 ---
+hash_str() {
+  local data="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$data" | sha256sum | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$data" | shasum -a 256 | awk '{print $1}'
+  else
+    echo "ERROR: neither sha256sum nor shasum available" >&2
+    exit 2
+  fi
+}
+
+hash_file() {
+  local path="$1"
+  if [ ! -f "$path" ]; then
+    echo "MISSING"
+    return 0
+  fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$path" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$path" | awk '{print $1}'
+  else
+    echo "ERROR: neither sha256sum nor shasum available" >&2
+    exit 2
+  fi
+}
+
+# --- 1. Cache file present? ---
+[ -f "$CACHE_FILE" ] || miss "no cache file at $CACHE_FILE"
+
+# --- 2. jq available for parsing? ---
+command -v jq >/dev/null 2>&1 || miss "jq not available (required for cache parsing)"
+
+# --- 3. Schema version matches? ---
+cached_schema=$(jq -r '.schemaVersion // empty' "$CACHE_FILE" 2>/dev/null)
+[ "$cached_schema" = "$SCHEMA_VERSION" ] || miss "schemaVersion mismatch (cache: ${cached_schema:-empty}, expected: $SCHEMA_VERSION)"
+
+# --- 4. Plugin version matches? ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+MARKETPLACE_JSON="$(cd "$PLUGIN_ROOT/.." && pwd)/.claude-plugin/marketplace.json"
+
+if [ -f "$MARKETPLACE_JSON" ]; then
+  current_version=$(jq -r --arg name "$PLUGIN_NAME" '.plugins[] | select(.name==$name) | .version' "$MARKETPLACE_JSON" 2>/dev/null)
+  cached_version=$(jq -r '.pluginVersion // empty' "$CACHE_FILE")
+  if [ -n "$current_version" ] && [ "$current_version" != "$cached_version" ]; then
+    miss "pluginVersion changed (cache: $cached_version, current: $current_version)"
+  fi
+fi
+
+# --- 5. Compute current fingerprints ---
+if [ -f "CLAUDE.md" ]; then
+  arness_section=$(awk '/^## Arness$/{flag=1;next} /^## /{flag=0} flag' CLAUDE.md)
+  current_arness_section_hash=$(hash_str "$arness_section")
+else
+  current_arness_section_hash="MISSING"
+fi
+
+current_agent_models_hash=$(hash_file ".arness/agent-models/${SHORT_NAME}.md")
+current_agent_models_checksums_hash=$(hash_file ".arness/agent-models/.checksums.json")
+current_templates_checksums_hash=$(hash_file ".arness/templates/.checksums.json")
+current_user_profile_hash=$(hash_file "$HOME/.arness/user-profile.yaml")
+current_profile_override_hash=$(hash_file ".claude/arness-profile.local.md")
+current_gitignore_hash=$(hash_file ".gitignore")
+
+# --- 6. Compare against cache ---
+# Use parallel indexed arrays (bash 3.2 compatible — Mac's default /bin/bash is 3.2,
+# associative arrays via 'declare -A' are bash 4+ only).
+KEYS=(claudeMdArnessSection agentModelsCodeMd agentModelsChecksums templatesChecksums userProfile profileOverride gitignoreContent)
+VALUES=(
+  "$current_arness_section_hash"
+  "$current_agent_models_hash"
+  "$current_agent_models_checksums_hash"
+  "$current_templates_checksums_hash"
+  "$current_user_profile_hash"
+  "$current_profile_override_hash"
+  "$current_gitignore_hash"
+)
+
+i=0
+while [ $i -lt ${#KEYS[@]} ]; do
+  key="${KEYS[$i]}"
+  current="${VALUES[$i]}"
+  cached=$(jq -r ".fingerprints.${key} // empty" "$CACHE_FILE")
+  if [ "$cached" != "$current" ]; then
+    miss "fingerprint $key changed (cache: ${cached:0:16}..., current: ${current:0:16}...)"
+  fi
+  i=$((i + 1))
+done
+
+# --- 7. GitHub labels check (only if Platform=github AND gh available) ---
+if [ -f "CLAUDE.md" ]; then
+  platform=$(grep -E '^- \*\*Platform:\*\*' CLAUDE.md 2>/dev/null | head -1 | sed -E 's/.*Platform:\*\*\s*//')
+  if [ "$platform" = "github" ] && command -v gh >/dev/null 2>&1; then
+    label_count=$(gh label list --json name --jq '.[].name' 2>/dev/null | grep -c '^arness-' || echo 0)
+    if [ "$label_count" != "$EXPECTED_LABELS_COUNT" ]; then
+      miss "GitHub arness-* label count is $label_count, expected $EXPECTED_LABELS_COUNT"
+    fi
+  fi
+fi
+
+exit 0

--- a/plugins/arn-infra/skills/arn-infra-env/SKILL.md
+++ b/plugins/arn-infra/skills/arn-infra-env/SKILL.md
@@ -162,7 +162,7 @@ Based on the IaC tool, generate environment-specific configuration files:
 | Kubernetes | `environments/<env>/kustomization.yaml` or `values-<env>.yaml` | Kustomize overlays or Helm value overrides |
 | PaaS (none) | Platform-native env config | Environment-specific sections in `fly.toml`, `vercel.json` |
 
-Invoke the `arn-infra-specialist` agent via the Task tool with:
+Invoke the `arn-infra-specialist` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 --- ENVIRONMENT CONTEXT ---
 Environments: [list in promotion order]

--- a/plugins/arn-infra/skills/arn-infra-execute-change/SKILL.md
+++ b/plugins/arn-infra/skills/arn-infra-execute-change/SKILL.md
@@ -122,7 +122,7 @@ Generate environment-specific variable files. Include resource tagging.
 
 > Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-execute-change/references/gate-policies.md` for security gate enforcement rules.
 
-Invoke the `arn-infra-security-auditor` agent to scan the generated IaC:
+Invoke the `arn-infra-security-auditor` agent via the Task tool to scan the generated IaC, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 ```text
 --- IaC ARTIFACTS ---
@@ -151,7 +151,7 @@ Update PROGRESS_TRACKER.json: set `securityGate.status`.
 
 #### Step 2.4: Cost Gate (arn-infra-cost-analyst)
 
-Invoke the `arn-infra-cost-analyst` agent to estimate costs:
+Invoke the `arn-infra-cost-analyst` agent via the Task tool to estimate costs, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 ```text
 --- IaC ARTIFACTS ---
@@ -192,7 +192,7 @@ Execute the deployment using the procedures from `deploy-procedures.md`. Follow 
 
 #### Step 2.6: Verification (arn-infra-verifier)
 
-Invoke the `arn-infra-verifier` agent to validate the deployment:
+Invoke the `arn-infra-verifier` agent via the Task tool to validate the deployment, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 ```text
 --- DEPLOYED RESOURCES ---
@@ -215,7 +215,7 @@ Update PROGRESS_TRACKER.json: set `verification.status`.
 
 #### Step 2.7: Review Gate (arn-infra-change-reviewer)
 
-Invoke the `arn-infra-change-reviewer` agent for a phase-level review:
+Invoke the `arn-infra-change-reviewer` agent via the Task tool for a phase-level review, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 ```text
 --- PHASE REPORT ---

--- a/plugins/arn-infra/skills/arn-infra-execute-change/references/dispatch-loop.md
+++ b/plugins/arn-infra/skills/arn-infra-execute-change/references/dispatch-loop.md
@@ -30,7 +30,7 @@ Before any changes, create a rollback checkpoint.
 
 ### Step 2: IaC Generation (arn-infra-specialist)
 
-Invoke the `arn-infra-specialist` agent with:
+Invoke the `arn-infra-specialist` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 ```text
 --- PHASE PLAN ---
@@ -62,7 +62,7 @@ with: environment, project, managed-by=arn-infra, phase=N.
 
 ### Step 3: Security Gate (arn-infra-security-auditor)
 
-Invoke the `arn-infra-security-auditor` agent with:
+Invoke the `arn-infra-security-auditor` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 ```text
 --- IaC ARTIFACTS ---
@@ -90,7 +90,7 @@ CRITICAL, HIGH, MEDIUM, LOW. Check for:
 
 ### Step 4: Cost Gate (arn-infra-cost-analyst)
 
-Invoke the `arn-infra-cost-analyst` agent with:
+Invoke the `arn-infra-cost-analyst` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 ```text
 --- IaC ARTIFACTS ---
@@ -126,7 +126,7 @@ Execute deployment using procedures from `deploy-procedures.md`:
 
 ### Step 6: Verification (arn-infra-verifier)
 
-Invoke the `arn-infra-verifier` agent with:
+Invoke the `arn-infra-verifier` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 ```text
 --- DEPLOYED RESOURCES ---
@@ -150,7 +150,7 @@ Report PASS/WARN/FAIL verdict.
 
 ### Step 7: Review Gate (arn-infra-change-reviewer)
 
-Invoke the `arn-infra-change-reviewer` agent with:
+Invoke the `arn-infra-change-reviewer` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 ```text
 --- PHASE REPORT ---

--- a/plugins/arn-infra/skills/arn-infra-init/SKILL.md
+++ b/plugins/arn-infra/skills/arn-infra-init/SKILL.md
@@ -117,7 +117,7 @@ Options:
 Experience level governs conversational tone and recommendations throughout the init flow. Instead of asking the user directly, derive the experience level from the user profile.
 
 1. Read the user profile from `~/.arness/user-profile.yaml` or `.claude/arness-profile.local.md` (project override takes precedence)
-2. If no user profile exists, run the welcome flow first by reading `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-ensure-config/references/ensure-config.md` -- the welcome flow creates the profile
+2. If no user profile exists, run the welcome flow first by reading `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-ensure-config/references/step-0-fast-path.md` -- the welcome flow creates the profile
 3. Apply the experience derivation mapping at `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-ensure-config/references/experience-derivation.md` to determine the infrastructure experience level (expert, intermediate, or beginner)
 4. If the derivation is ambiguous (the mapping indicates a follow-up is needed), ask one focused question: "For infrastructure specifically, would you say expert, intermediate, or beginner?"
 5. Use the derived experience level for all subsequent steps (provider recommendations, cost threshold defaults, etc.)
@@ -261,6 +261,24 @@ Ask:
 
 ---
 
+### Step 7.5: Choose Model Profile for arn-infra Agents
+
+Run the **Profile selection** procedure documented in `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-ensure-config/references/step-0-fast-path.md` under the "Model profile field" section. That procedure is the single source of truth for the prompt + write + copy + checksum flow — do NOT duplicate the AskUserQuestion or file-copy logic here.
+
+The procedure performs (in order):
+1. Cross-plugin default suggestion (read sibling plugin profile fields if present in the existing `## Arness` block — e.g., if the user previously chose `balanced` for arn-code or arn-spark, suggest `balanced` here too)
+2. AskUserQuestion with title "Choose model profile for arn-infra agents" and two options: `all-opus` (default unless a sibling chose `balanced`) and `balanced`
+3. Append `- **Infra agent model profile:** <choice>` to the `## Arness` block
+4. `mkdir -p .arness/agent-models/` then copy `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-init/references/agent-models-presets/<choice>.md` to `.arness/agent-models/infra.md`
+5. Compute SHA-256 and record it in `.arness/agent-models/.checksums.json` along with the profile name and version
+6. Inform the user with a one-line confirmation
+
+The field write in step 3 of the procedure is captured for the CLAUDE.md write in Step 8 of this init flow — write the chosen value to a holding variable and let Step 8 emit it inline with all other fields. The preset copy + checksum (steps 4-5 of the procedure) happen here regardless of when the CLAUDE.md write is performed.
+
+Record the chosen profile for the config write in Step 8.
+
+---
+
 ### Step 8: Create Infrastructure Files and Write Configuration
 
 1. Create infrastructure directory structure:
@@ -331,6 +349,7 @@ Ask:
    - **Infra report templates:** default
    - **Infra template path:** .arness/infra-templates
    - **Infra template version:** <version from plugin.json>
+   - **Infra agent model profile:** all-opus | balanced | custom
    - **Git:** [yes | no]
    - **Platform:** [github | bitbucket | none]
    - **CI/CD platform:** [github-actions | gitlab-ci | bitbucket-pipelines | none]

--- a/plugins/arn-infra/skills/arn-infra-init/references/agent-models-presets/all-opus.md
+++ b/plugins/arn-infra/skills/arn-infra-init/references/agent-models-presets/all-opus.md
@@ -1,0 +1,13 @@
+# Profile: all-opus
+# Version: 1.0.0
+
+arn-infra-change-planner: opus
+arn-infra-change-reviewer: opus
+arn-infra-cost-analyst: opus
+arn-infra-doctor: opus
+arn-infra-pipeline-builder: opus
+arn-infra-reference-researcher: opus
+arn-infra-request-analyzer: opus
+arn-infra-security-auditor: opus
+arn-infra-specialist: opus
+arn-infra-verifier: opus

--- a/plugins/arn-infra/skills/arn-infra-init/references/agent-models-presets/balanced.md
+++ b/plugins/arn-infra/skills/arn-infra-init/references/agent-models-presets/balanced.md
@@ -1,0 +1,13 @@
+# Profile: balanced
+# Version: 1.0.0
+
+arn-infra-change-planner: opus
+arn-infra-change-reviewer: opus
+arn-infra-cost-analyst: opus
+arn-infra-doctor: sonnet
+arn-infra-pipeline-builder: sonnet
+arn-infra-reference-researcher: sonnet
+arn-infra-request-analyzer: opus
+arn-infra-security-auditor: opus
+arn-infra-specialist: opus
+arn-infra-verifier: sonnet

--- a/plugins/arn-infra/skills/arn-infra-migrate/SKILL.md
+++ b/plugins/arn-infra/skills/arn-infra-migrate/SKILL.md
@@ -117,7 +117,7 @@ Based on the chosen scenario:
 
 #### 4.1: Generate Migration Plan
 
-Invoke the `arn-infra-specialist` agent via the Task tool with:
+Invoke the `arn-infra-specialist` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 --- MIGRATION CONTEXT ---
 Scenario: [graduate | provider-migration | consolidation | partial]
@@ -139,7 +139,7 @@ Generate a migration plan covering:
 
 #### 4.2: Get Cost Comparison
 
-Invoke the `arn-infra-cost-analyst` agent via the Task tool with:
+Invoke the `arn-infra-cost-analyst` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 --- COST CONTEXT ---
 Source infrastructure: [current provider resources and costs]
@@ -246,7 +246,7 @@ Execute migration steps incrementally. For each task:
 
 Adapt IaC generation instructions to experience level (beginner: simplified configs with comments, expert: production-ready with minimal comments).
 
-Invoke the `arn-infra-specialist` agent to generate IaC for the target provider/service. Follow the same patterns as `arn-infra-define`: invoke the `arn-infra-specialist` agent via the Task tool with the target provider's IaC tool and patterns reference, scoped to the specific migration task.
+Invoke the `arn-infra-specialist` agent to generate IaC for the target provider/service. Follow the same patterns as `arn-infra-define`: invoke the `arn-infra-specialist` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback), with the target provider's IaC tool and patterns reference, scoped to the specific migration task.
 
 **6.2: Deploy to staging**
 

--- a/plugins/arn-infra/skills/arn-infra-monitor/SKILL.md
+++ b/plugins/arn-infra/skills/arn-infra-monitor/SKILL.md
@@ -190,7 +190,7 @@ Options:
 
 ### Step 6: Generate Monitoring IaC
 
-Invoke the `arn-infra-specialist` agent via the Task tool with:
+Invoke the `arn-infra-specialist` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 --- MONITORING CONTEXT ---
 Observability stack: [chosen stack]

--- a/plugins/arn-infra/skills/arn-infra-pipeline/SKILL.md
+++ b/plugins/arn-infra/skills/arn-infra-pipeline/SKILL.md
@@ -116,7 +116,7 @@ Load the security checklist:
 
 ### Step 4: Invoke Pipeline Builder Agent
 
-Invoke the `arn-infra-pipeline-builder` agent via the Task tool with:
+Invoke the `arn-infra-pipeline-builder` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 --- PLATFORM CONTEXT ---
 CI/CD platform: [github-actions | gitlab-ci | bitbucket-pipelines]
@@ -188,7 +188,7 @@ Verify that the pipeline builder agent returned at least one pipeline configurat
 
 ### Step 5: Invoke Security Auditor for Pipeline Review
 
-Invoke the `arn-infra-security-auditor` agent via the Task tool with:
+Invoke the `arn-infra-security-auditor` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 --- FILES TO AUDIT ---
 [Generated pipeline configuration files from Step 4]

--- a/plugins/arn-infra/skills/arn-infra-refresh/SKILL.md
+++ b/plugins/arn-infra/skills/arn-infra-refresh/SKILL.md
@@ -134,7 +134,7 @@ For each file in the selected categories:
 1. Read the current content of the local override file from the **Reference overrides** path. If the file is missing, copy it from the plugin default (`${CLAUDE_PLUGIN_ROOT}/skills/<source-path-from-manifest>`) before proceeding, and record the copy in `.reference-checksums.json` with `updatedBy: "init"`.
 2. Read the research strategy for the file's category from `research-strategies.md`
 
-Invoke the `arn-infra-reference-researcher` agent via the Task tool with:
+Invoke the `arn-infra-reference-researcher` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 ```text
 --- CURRENT FILE CONTENT ---

--- a/plugins/arn-infra/skills/arn-infra-report/SKILL.md
+++ b/plugins/arn-infra/skills/arn-infra-report/SKILL.md
@@ -72,7 +72,7 @@ If GitHub access is not available, offer an alternative: generate the diagnostic
 
 ### Step 4: Invoke arn-infra-doctor
 
-Spawn the `arn-infra-doctor` agent via the Task tool with:
+Spawn the `arn-infra-doctor` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - The user's description of the issue
 - Project root path
 - `## Arness` config content (or "not configured")

--- a/plugins/arn-infra/skills/arn-infra-review-change/SKILL.md
+++ b/plugins/arn-infra/skills/arn-infra-review-change/SKILL.md
@@ -89,7 +89,7 @@ Options:
 
 ### Step 2: Invoke the Change Reviewer Agent
 
-Invoke the `arn-infra-change-reviewer` agent via the Task tool with structured context:
+Invoke the `arn-infra-change-reviewer` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Structured context:
 
 ```text
 --- PHASE REPORTS ---

--- a/plugins/arn-infra/skills/arn-infra-secrets/SKILL.md
+++ b/plugins/arn-infra/skills/arn-infra-secrets/SKILL.md
@@ -41,7 +41,7 @@ Extract:
 
 ### Step 1: Scan for Existing Secrets Patterns
 
-Invoke the `arn-infra-security-auditor` agent via the Task tool with:
+Invoke the `arn-infra-security-auditor` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 --- FILES TO AUDIT ---
 Scan the entire project for secrets patterns:

--- a/plugins/arn-infra/skills/arn-infra-triage/SKILL.md
+++ b/plugins/arn-infra/skills/arn-infra-triage/SKILL.md
@@ -75,7 +75,7 @@ If the issue does not follow the template format:
 
 ### Step 3: Invoke the Request Analyzer Agent
 
-Invoke the `arn-infra-request-analyzer` agent via the Task tool with:
+Invoke the `arn-infra-request-analyzer` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 ```text
 --- ISSUE CONTEXT ---

--- a/plugins/arn-infra/skills/arn-infra-verify/SKILL.md
+++ b/plugins/arn-infra/skills/arn-infra-verify/SKILL.md
@@ -108,7 +108,7 @@ If the user provides URLs manually, proceed with those as the expected state.
 
 > Read the local override or plugin default for `health-check-patterns.md`.
 
-Invoke the `arn-infra-verifier` agent via the Task tool with:
+Invoke the `arn-infra-verifier` agent via the Task tool, passing the model from `.arness/agent-models/infra.md` as the `model` parameter (see `plugins/arn-infra/skills/arn-infra-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 --- EXPECTED STATE ---
 Resources: [filtered resource manifest for the target environment]

--- a/plugins/arn-infra/skills/arn-infra-wizard/SKILL.md
+++ b/plugins/arn-infra/skills/arn-infra-wizard/SKILL.md
@@ -22,7 +22,7 @@ This skill is a **sequencer and decision-gate handler**. It MUST NOT duplicate s
 
 ## Step 0: Ensure Configuration
 
-Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-ensure-config/references/ensure-config.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Infra fields before proceeding.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-ensure-config/references/step-0-fast-path.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Infra fields before proceeding.
 
 After Step 0 completes, read `${CLAUDE_PLUGIN_ROOT}/skills/arn-infra-ensure-config/references/experience-derivation.md` and derive the user's infrastructure experience level from their profile.
 

--- a/plugins/arn-spark/skills/arn-brainstorming/SKILL.md
+++ b/plugins/arn-spark/skills/arn-brainstorming/SKILL.md
@@ -24,7 +24,7 @@ This skill is a **sequencer and decision-gate handler**. It MUST NOT duplicate s
 
 ## Step 0: Ensure Configuration
 
-Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-ensure-config/references/ensure-config.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Spark fields before proceeding.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-ensure-config/references/step-0-fast-path.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Spark fields before proceeding.
 
 After Step 0 completes, extract from `## Arness`:
 - Vision directory, Use cases directory, Prototypes directory, Spikes directory, Visual grounding directory, Reports directory

--- a/plugins/arn-spark/skills/arn-spark-arch-vision/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-arch-vision/SKILL.md
@@ -21,7 +21,7 @@ This skill covers the HOW at a high level: what technologies to use and how the 
 
 ## Step 0: Ensure Configuration
 
-Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-ensure-config/references/ensure-config.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Spark fields before proceeding.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-ensure-config/references/step-0-fast-path.md` and follow its instructions. This guarantees a user profile exists and `## Arness` is configured with Arness Spark fields before proceeding.
 
 After Step 0 completes, extract from `## Arness`:
 - Vision directory, Use cases directory, Prototypes directory, Spikes directory, Visual grounding directory, Reports directory
@@ -81,7 +81,7 @@ Wait for user confirmation or corrections before proceeding.
 
 Read the user profile for expertise context. Check `.claude/arness-profile.local.md` first (project override takes precedence), then `~/.arness/user-profile.yaml`. Also check `.arness/preferences.yaml` for project-level team preferences.
 
-Invoke the `arn-spark-tech-evaluator` agent with:
+Invoke the `arn-spark-tech-evaluator` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - The product concept (or extracted requirements)
 - The full set of technical requirements from Step 1
 - The product pillars from Step 1

--- a/plugins/arn-spark/skills/arn-spark-clickable-prototype-teams/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-clickable-prototype-teams/SKILL.md
@@ -321,7 +321,7 @@ For each cycle:
 
 #### 5a: Build
 
-Invoke the `arn-spark-prototype-builder` agent with:
+Invoke the `arn-spark-prototype-builder` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - **Screen list:** with descriptions and navigation flow
 - **Style brief:** toolkit configuration section
 - **UI framework and component library:** from architecture vision or the project's dependency configuration
@@ -340,7 +340,7 @@ Start the prototype so it can be interacted with:
 3. Wait for it to be ready (e.g., poll a URL for web-based prototypes, wait for the process to report ready)
 4. Note the process ID for cleanup
 
-Then invoke the `arn-spark-ui-interactor` agent with:
+Then invoke the `arn-spark-ui-interactor` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - **Prototype URL or access point:** how to reach the running prototype (e.g., a URL for web-based, or launch instructions for native)
 - **User journey definitions:** the journeys agreed in Step 2b/Step 3
 - **Output path:** `prototypes/clickable/v[N]/journeys/`
@@ -487,7 +487,7 @@ Start the prototype for the judge's interactive review using the same procedure 
 
 If the prototype fails to start, fall back to invoking the judge in `static` mode using the journey screenshots from the latest Step 5b cycle. Note the limitation in the final report.
 
-Once the prototype is running, invoke the `arn-spark-ux-judge` agent with:
+Once the prototype is running, invoke the `arn-spark-ux-judge` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - **Review mode:** `interactive` -- the judge navigates the prototype firsthand rather than reviewing static screenshots
 - **Prototype URL or access point:** how to reach the running prototype
 - **Criteria list:** from `prototypes/criteria.md`

--- a/plugins/arn-spark/skills/arn-spark-clickable-prototype-teams/references/debate-protocol.md
+++ b/plugins/arn-spark/skills/arn-spark-clickable-prototype-teams/references/debate-protocol.md
@@ -160,7 +160,7 @@ When Agent Teams is not enabled, the skill simulates the debate with 3 sequentia
 
 **Invocation 1 -- Product Strategist Phase 1:**
 
-Invoke `arn-spark-product-strategist` with:
+Invoke the `arn-spark-product-strategist` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - Journey screenshots from interaction testing step
 - Interaction report from `arn-spark-ui-interactor`
 - All criteria with descriptions, scoring scale, and threshold
@@ -171,7 +171,7 @@ Invoke `arn-spark-product-strategist` with:
 
 **Invocation 2 -- UX Specialist Phase 1 + Phase 2 Combined:**
 
-Invoke `arn-spark-ux-specialist` with:
+Invoke the `arn-spark-ux-specialist` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - Same inputs as Invocation 1
 - The strategist's file path to read: `prototypes/clickable/reviews/round-N-strategist-review.md`
 - File path to write to: `prototypes/clickable/reviews/round-N-ux-review.md`
@@ -179,7 +179,7 @@ Invoke `arn-spark-ux-specialist` with:
 
 **Invocation 3 -- Product Strategist Phase 2:**
 
-Invoke `arn-spark-product-strategist` with:
+Invoke the `arn-spark-product-strategist` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - The UX specialist's file path to read: `prototypes/clickable/reviews/round-N-ux-review.md`
 - Expert interaction review template path
 - File path to write to: `prototypes/clickable/reviews/round-N-strategist-cross-review.md`

--- a/plugins/arn-spark/skills/arn-spark-clickable-prototype/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-clickable-prototype/SKILL.md
@@ -241,7 +241,7 @@ For each cycle:
 
 #### 4a: Build
 
-Invoke the `arn-spark-prototype-builder` agent with:
+Invoke the `arn-spark-prototype-builder` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - **Screen list:** with descriptions and navigation flow
 - **Style brief:** toolkit configuration section
 - **UI framework and component library:** from architecture vision or the project's dependency configuration
@@ -261,7 +261,7 @@ Start the prototype so it can be interacted with:
 3. Wait for it to be ready (e.g., poll a URL for web-based prototypes, wait for the process to report ready)
 4. Note the process ID for cleanup
 
-Then invoke the `arn-spark-ui-interactor` agent with:
+Then invoke the `arn-spark-ui-interactor` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - **Prototype URL or access point:** how to reach the running prototype (e.g., a URL for web-based, or launch instructions for native)
 - **User journey definitions:** the journeys agreed in Step 1b/Step 2
 - **Output path:** `prototypes/clickable/v[N]/journeys/`
@@ -312,7 +312,7 @@ Start the prototype for the judge's interactive review using the same procedure 
 
 If the prototype fails to start, fall back to invoking the judge in `static` mode using the journey screenshots from the latest Step 4b cycle. Note the limitation in the final report.
 
-Once the prototype is running, invoke the `arn-spark-ux-judge` agent with:
+Once the prototype is running, invoke the `arn-spark-ux-judge` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - **Review mode:** `interactive` -- the judge navigates the prototype firsthand rather than reviewing static screenshots
 - **Prototype URL or access point:** how to reach the running prototype
 - **Criteria list:** from `prototypes/criteria.md`

--- a/plugins/arn-spark/skills/arn-spark-concept-review/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-concept-review/SKILL.md
@@ -101,7 +101,7 @@ Also read the current product concept from `<vision-dir>/product-concept.md`. Ex
 
 ### Step 3: Invoke Product Strategist for Consolidation
 
-Invoke the `arn-spark-product-strategist` agent with:
+Invoke the `arn-spark-product-strategist` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 --- PRODUCT CONCEPT ---
 [full product concept content]
@@ -145,7 +145,7 @@ Check the product concept content for signals that the UX specialist was involve
 
 **If UX signals are detected:**
 
-Identify which recommendations in the consolidated changeset affect UX-relevant sections (Core Experience, visual direction, interaction patterns, onboarding flows, accessibility). If any exist, invoke `arn-spark-ux-specialist` with:
+Identify which recommendations in the consolidated changeset affect UX-relevant sections (Core Experience, visual direction, interaction patterns, onboarding flows, accessibility). If any exist, invoke the `arn-spark-ux-specialist` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 --- PRODUCT CONCEPT ---
 [full product concept content]

--- a/plugins/arn-spark/skills/arn-spark-dev-setup/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-dev-setup/SKILL.md
@@ -179,7 +179,7 @@ Ready to generate, or want to adjust anything?"
 
 ### Step 5: Invoke Builder
 
-Invoke the `arn-spark-dev-env-builder` agent with:
+Invoke the `arn-spark-dev-env-builder` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 - Environment type and all specifics gathered in Step 4
 - Platform targets

--- a/plugins/arn-spark/skills/arn-spark-discover/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-discover/SKILL.md
@@ -20,7 +20,7 @@ This skill covers the WHAT and WHY of the product, including the **product pilla
 
 ## Step 0: Ensure Configuration (Non-Blocking)
 
-Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-ensure-config/references/ensure-config.md` and follow its instructions. This captures the user profile and configures `## Arness` with Arness Spark fields.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-ensure-config/references/step-0-fast-path.md` and follow its instructions. This captures the user profile and configures `## Arness` with Arness Spark fields.
 
 **Important:** This skill is designed for exploratory use before a project may fully exist. If ensure-config encounters errors (e.g., no git repository, CLAUDE.md cannot be created), proceed anyway using fallback defaults: Vision directory = `.arness/vision`, Reports directory = `.arness/reports`. Do not hard-block.
 
@@ -42,7 +42,7 @@ After receiving the idea, acknowledge with a brief restatement (2-3 sentences) t
 
 ### Step 2: Initial Analysis with Product Strategist
 
-Invoke the `arn-spark-product-strategist` agent with:
+Invoke the `arn-spark-product-strategist` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - The user's raw idea description
 - Any context from the conversation so far
 
@@ -107,7 +107,7 @@ This is a two-phase process: **concrete examples first** (for user interaction),
      > **I can expand those into full profiles with personality traits, pain points, and day-in-the-life scenarios. Want me to research and draft those?**
      > 1. **Yes** — Expand into full persona profiles
      > 2. **No** — Keep as-is and continue
-3. If agreed, invoke `arn-spark-persona-architect` in **discovery mode** with: product vision, problem statement, user description (vague or concrete seeds), product pillars so far. The agent handles both cases -- generating from scratch or expanding user-provided specifics.
+3. If agreed, invoke the `arn-spark-persona-architect` agent in **discovery mode** via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context: product vision, problem statement, user description (vague or concrete seeds), product pillars so far. The agent handles both cases -- generating from scratch or expanding user-provided specifics.
 4. **Phase 1 -- Concrete examples:** Present the generated/expanded concrete personas (including personality traits): "Here are some specific people who would use this product. Do these ring true? Any to add, remove, or change?" The user interacts with these -- critiquing, adjusting, approving. Iterate until the user is satisfied. These are vivid, specific characters with personality.
 5. **Phase 2 -- Abstracted moulds:** Once concrete personas are approved, invoke the persona-architect again (or in the same pass) to derive the abstracted profiles (moulds) from the approved examples. Present: "Here are the generalized persona archetypes I've extracted from the examples. These moulds can be used later to generate more personas for testing. Do they capture the pattern?" The moulds define ranges, patterns, personality spectrums, and variation axes rather than single points.
 6. Record both: the approved concrete examples AND the abstracted moulds.
@@ -149,7 +149,7 @@ Framing adapts based on product type:
 
 This process ensures thorough, validated results rather than a shallow 3-query search:
 
-1. **Phase 1 -- Query Planning:** Invoke `arn-spark-market-researcher` (identification/plan) with: product description, problem space, known competitors. The agent generates 10-15 search queries across diverse angles (problem-focused, solution-focused, comparison, review, community, domain). Present the query plan briefly: "I've identified [N] search angles to explore. Searching now..."
+1. **Phase 1 -- Query Planning:** Invoke the `arn-spark-market-researcher` agent (identification/plan) via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context: product description, problem space, known competitors. The agent generates 10-15 search queries across diverse angles (problem-focused, solution-focused, comparison, review, community, domain). Present the query plan briefly: "I've identified [N] search angles to explore. Searching now..."
 
 2. **Phase 2 -- Parallel Search:** Split the queries into 2-3 batches. Invoke `arn-spark-market-researcher` (identification/search) **2-3 times in parallel**, each with a batch of 4-6 queries. Each agent searches independently and returns raw findings.
 

--- a/plugins/arn-spark/skills/arn-spark-ensure-config/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-ensure-config/SKILL.md
@@ -3,20 +3,21 @@ name: arn-spark-ensure-config
 description: >-
   This skill should be used when the user says "ensure config", "check arn spark config",
   "arn-spark-ensure-config", "verify arn spark setup", "configure spark", "setup arness spark",
-  "spark config", or wants to verify that Arness Spark
-  configuration is present for the current project. This skill is primarily consumed
-  as a reference by entry-point skills (arn-brainstorming, arn-spark-discover,
-  arn-spark-arch-vision) which read the ensure-config reference as Step 0 before
-  proceeding with their workflow.
-version: 1.0.0
+  "spark config", or wants to verify that Arness Spark configuration is present for the
+  current project. This skill is primarily consumed as a reference by entry-point skills
+  (arn-brainstorming, arn-spark-discover, arn-spark-arch-vision) which read the
+  `references/step-0-fast-path.md` reference as Step 0 before proceeding with their workflow.
+version: 1.1.0
 ---
 
 # Arness Spark Ensure Config
 
-Verify and establish Arness Spark configuration for the current project. This skill guarantees that a valid user profile and `## Arness` section exist before any Arness Spark workflow proceeds. It runs automatically as Step 0 of all entry-point skills.
+Verify and establish Arness Spark configuration for the current project. This skill guarantees that a valid user profile and `## Arness` section exist before any Arness Spark workflow proceeds. It runs automatically as Step 0 of all entry-point skills via a hash-based fast-path cache.
 
-When invoked directly, it performs the same checks and setup as when called by an entry-point skill.
+**Entry points should NOT read this SKILL.md directly.** They should read `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-ensure-config/references/step-0-fast-path.md`, which runs the cache-check shell script and only falls through to the full validation when needed. This indirection is what saves ~95% of ensure-config token cost.
+
+When invoked DIRECTLY (rare — typically via `/arn-spark-ensure-config`), this skill bypasses the cache and runs the full validation flow.
 
 ## Workflow
 
-Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-ensure-config/references/ensure-config.md` and follow its instructions.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-ensure-config/references/ensure-config.md` and follow its instructions (Layers 1–2, then Layer 3 cache write).

--- a/plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md
+++ b/plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md
@@ -8,66 +8,6 @@ Follow the layers below in order. Each layer has a fast path (skip when already 
 
 ---
 
-## Layer 0: Migration Check (Nova to Arness)
-
-This layer runs before everything else. It silently migrates legacy Nova artifacts to the Arness naming convention. All steps are idempotent — safe to run multiple times. No user prompts; log-only. If any migration step fails, log the error and continue (do not hard-block — consistent with Spark's resilience pattern).
-
-### 0a. Project Directory
-
-Check via Bash:
-```bash
-test -d .nova && echo "OLD_EXISTS" || echo "OLD_MISSING"
-test -d .arness && echo "NEW_EXISTS" || echo "NEW_MISSING"
-```
-
-- If `.nova/` exists AND `.arness/` does NOT exist: run `mv .nova .arness`. Log: "Migrated project directory: .nova/ -> .arness/"
-- If both exist: skip (safety). Log: "Both .nova/ and .arness/ exist — skipping directory migration"
-- Otherwise: no action needed.
-
-### 0b. CLAUDE.md Config Section
-
-Read CLAUDE.md (if it exists) and check for `## Nova` and `## Arness` headers.
-
-- If `## Nova` exists AND `## Arness` does NOT exist: replace `## Nova` with `## Arness` in CLAUDE.md. Log: "Migrated config section: ## Nova -> ## Arness"
-- If both exist: skip (safety). Log: "Both ## Nova and ## Arness sections exist — skipping section migration"
-- Otherwise: no action needed.
-
-### 0c. User Home Directory
-
-Check via Bash:
-```bash
-test -d ~/.nova && echo "OLD_EXISTS" || echo "OLD_MISSING"
-test -d ~/.arness && echo "NEW_EXISTS" || echo "NEW_MISSING"
-```
-
-- If `~/.nova/` exists AND `~/.arness/` does NOT exist: run `mv ~/.nova ~/.arness`. Log: "Migrated user directory: ~/.nova/ -> ~/.arness/"
-- If both exist: skip (safety). Log: "Both ~/.nova/ and ~/.arness/ exist — skipping user directory migration"
-- Otherwise: no action needed.
-
-### 0d. Gitignore
-
-Read `.gitignore` (if it exists) and check for `.nova/*.local.yaml`.
-
-- If `.gitignore` contains `.nova/*.local.yaml` but NOT `.arness/*.local.yaml`: replace `.nova/*.local.yaml` with `.arness/*.local.yaml`. Log: "Updated .gitignore: .nova/*.local.yaml -> .arness/*.local.yaml"
-- If both patterns exist: skip (safety).
-- Otherwise: no action needed.
-
-### 0e. Profile Reference
-
-Check via Bash:
-```bash
-test -f .claude/nova-profile.local.md && echo "OLD_EXISTS" || echo "OLD_MISSING"
-test -f .claude/arness-profile.local.md && echo "NEW_EXISTS" || echo "NEW_MISSING"
-```
-
-- If `.claude/nova-profile.local.md` exists AND `.claude/arness-profile.local.md` does NOT exist: run `mv .claude/nova-profile.local.md .claude/arness-profile.local.md`. Log: "Migrated profile: nova-profile.local.md -> arness-profile.local.md"
-- If both exist: skip (safety).
-- Otherwise: no action needed.
-
-After all migration steps complete (or are skipped), proceed to Layer 1.
-
----
-
 ## Layer 1: Profile Check (Welcome & Profile)
 
 ### 1a. Check for Existing Profile
@@ -161,12 +101,12 @@ technology_preferences:
 expertise_aware: true | false
 ```
 
-3. Verify `.claude/*.local.md`, `.claude/settings.local.json`, and `.arness/*.local.yaml` are in the project's `.gitignore`:
+3. Verify `.claude/*.local.md`, `.claude/settings.local.json`, and `.arness/*.local.*` are in the project's `.gitignore`:
    - Read `.gitignore` in the project root
-   - If `.gitignore` does not exist, create it with `.claude/settings.local.json`, `.claude/*.local.md`, and `.arness/*.local.yaml` as entries
+   - If `.gitignore` does not exist, create it with `.claude/settings.local.json`, `.claude/*.local.md`, and `.arness/*.local.*` as entries
    - If `.gitignore` exists but does not contain `.claude/*.local.md`, append `.claude/*.local.md` on a new line
    - If `.gitignore` exists but does not contain `.claude/settings.local.json`, append `.claude/settings.local.json` on a new line
-   - If `.gitignore` exists but does not contain `.arness/*.local.yaml`, append `.arness/*.local.yaml` on a new line
+   - If `.gitignore` exists but does not contain `.arness/*.local.*`, append `.arness/*.local.*` on a new line
    - **Important:** Do NOT gitignore the entire `.claude/` directory — `.claude/settings.json` and other project-level Claude Code settings should remain committable for team sharing.
    - **Important:** Do NOT gitignore the entire `.arness/` directory — `.arness/preferences.yaml` (team technology preferences) and other Arness project files must remain committable.
 4. Optionally create `.claude/arness-profile.local.md` if the user wants project-specific adjustments
@@ -226,6 +166,8 @@ Ask (using `AskUserQuestion`):
 
 Construct the `## Arness` section with all fields. If CLAUDE.md does not exist, create it with the `## Arness` section. If CLAUDE.md exists, append the section at the end.
 
+For the `Spark agent model profile:` field: do NOT default it here. Leave the field absent so Layer 2c routes to the **Profile selection** procedure (see "Model profile field" section below) on the next ensure-config invocation. This guarantees the user is asked rather than silently set to `all-opus`. The corresponding `.arness/agent-models/spark.md` file is created by the Profile selection procedure, not by this fast path.
+
 Fields to write:
 ```
 ## Arness
@@ -248,9 +190,9 @@ Run via Bash: `mkdir -p` for each configured directory (vision, use-cases, proto
 
 ### 2c. If `## Arness` Exists But Arness Spark Fields Are Missing
 
-Check for the presence of Arness Spark fields: `Vision directory`, `Use cases directory`, `Prototypes directory`, `Spikes directory`, `Visual grounding directory`, `Reports directory`.
+Check for the presence of Arness Spark fields: `Vision directory`, `Use cases directory`, `Prototypes directory`, `Spikes directory`, `Visual grounding directory`, `Reports directory`, `Spark agent model profile`.
 
-If any are missing:
+If any directory-style fields are missing (`Vision directory`, `Use cases directory`, `Prototypes directory`, `Spikes directory`, `Visual grounding directory`, `Reports directory`):
 
 1. Check the `Folder preference` field in the existing `## Arness` section.
 2. If `Folder preference: defaults` — silently add missing Spark fields with default values. Create directories via `mkdir -p`.
@@ -258,9 +200,162 @@ If any are missing:
 4. If no `Folder preference` field exists — add it with value `defaults` and silently add missing fields.
 5. **Preserve all existing fields** from other plugins (Code fields, Infra fields) per the CLAUDE.md Config Section pattern.
 
+If the `Spark agent model profile:` field is missing (separate logic — this field requires a real choice and downstream artifact copy):
+
+1. Run the **Profile selection** procedure documented in the "Model profile field" section below. The procedure handles the AskUserQuestion prompt, writes the field to the `## Arness` block, copies the chosen preset to `.arness/agent-models/spark.md`, and records the SHA-256 checksum.
+
+If the `Spark agent model profile:` field is **present** (consistency check — runs whether or not directory fields are also missing):
+
+1. **If value is `all-opus` or `balanced`:**
+   a. Compute the SHA-256 checksum of `.arness/agent-models/spark.md` and compare it to the recorded checksum in `.arness/agent-models/.checksums.json`.
+   b. If checksums **differ** (user edited the file): flip the field value in `## Arness` from its current value to `custom` and inform the user with a one-line message: `"Detected your edits to .arness/agent-models/spark.md — set profile to 'custom' so future updates won't overwrite your changes."` Do NOT overwrite the user's edits; do NOT recompute the checksum (the `custom` profile means "user-managed").
+   c. If checksums match: read the `# Version:` header from `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-init/references/agent-models-presets/<value>.md` (the upstream preset) and compare to the `# Version:` header recorded in `.arness/agent-models/spark.md`. If they differ, apply the project's `Template updates:` policy (reuse the procedure in `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-save-plan/references/template-versioning.md` — Spark reuses Arness Code's template-versioning machinery):
+      - `auto`: copy the new preset, regenerate the checksum, inform the user "Refreshed `.arness/agent-models/spark.md` from preset `<value>` v<old>→v<new>."
+      - `ask`: prompt the user; on accept, copy + regenerate; on decline, leave file alone and skip until the user re-runs.
+      - `manual`: do nothing this run.
+
+2. **If value is `custom`:**
+   a. Read the canonical agent list from `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-init/references/agent-models-presets/all-opus.md` (every entry of the form `<agent-name>: <model>`).
+   b. Read the user's `.arness/agent-models/spark.md` and collect the agent names present.
+   c. For any agent in the canonical list that is NOT present in the user's file, surface as an info-level diagnostic: `"Note: .arness/agent-models/spark.md is missing entries for: <comma-separated agent list>. Add them or run with 'all-opus'/'balanced' profile to refresh."` This is informational only — do not block the workflow.
+
+3. **If value is anything else** (legacy/typo): treat as missing — run the Profile selection procedure to repair.
+
 ### 2d. If `## Arness` Exists and All Spark Fields Are Present
 
-**Fast path.** No action needed. Proceed with the original skill's workflow.
+**Fast path.** Verify against the canonical Spark fields list at the top of section 2c — every field on that list (including `Spark agent model profile`) must be present. If `Spark agent model profile` is present, also run the checksum/version/custom-diagnostic checks documented in section 2c (they are cheap and idempotent). If all checks pass, no action needed; proceed with the original skill's workflow.
+
+---
+
+## Layer 3: Cache Write
+
+After Layers 1–2 complete successfully, write the validation cache so future ensure-config invocations can fast-path via `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-ensure-config/scripts/cache-check.sh`. This is the final step of the validation flow.
+
+### Why a cache?
+
+Entry-point skills invoke ensure-config as Step 0 on every workflow trigger (~30 trigger points across the plugin). Re-running the full Layers 1–2 flow on every invocation costs ~2k tokens even when nothing has changed. The cache lets the cache-check shell script (zero model tokens) verify validity in milliseconds; on hit, the entry-point skips reading this references file entirely (per the procedure in `references/step-0-fast-path.md`).
+
+### Cache file location
+
+`.arness/arn-spark-ensure-config.local.json` (project-local, gitignored via the `.arness/*.local.*` pattern from Layer 1c).
+
+### Cache schema
+
+```json
+{
+  "schemaVersion": 1,
+  "validatedAt": "2026-05-10T12:34:56Z",
+  "pluginVersion": "2.4.0",
+  "fingerprints": {
+    "claudeMdArnessSection": "<sha256 of the ## Arness block content>",
+    "agentModelsCodeMd": "<sha256 of .arness/agent-models/spark.md, or 'MISSING'>",
+    "agentModelsChecksums": "<sha256 of .arness/agent-models/.checksums.json, or 'MISSING'>",
+    "templatesChecksums": "<sha256 of .arness/templates/.checksums.json, or 'MISSING'>",
+    "userProfile": "<sha256 of ~/.arness/user-profile.yaml, or 'MISSING'>",
+    "profileOverride": "<sha256 of .claude/arness-profile.local.md, or 'MISSING'>",
+    "gitignoreContent": "<sha256 of .gitignore, or 'MISSING'>"
+  },
+  "validationStatus": "pass"
+}
+```
+
+(Note: the fingerprint key remains `agentModelsCodeMd` for cross-plugin schema consistency, but its value hashes the spark-specific file `.arness/agent-models/spark.md`.)
+
+### Write procedure
+
+1. **Compute the 7 fingerprints** using `sha256sum` (Linux + Git Bash) || `shasum -a 256` (Mac BSD). For the `claudeMdArnessSection` hash, extract the `## Arness` block via `awk '/^## Arness$/{flag=1;next} /^## /{flag=0} flag' CLAUDE.md` then pipe to the hasher. For each file fingerprint: if the file does not exist, use the literal string `MISSING` instead of computing a hash.
+
+2. **Read plugin version** from `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json` if present (legacy), else from the marketplace's `marketplace.json` entry for `arn-spark`. Use the empty string if neither is resolvable.
+
+3. **Construct the JSON object** with the schema above. `validatedAt` is the current ISO 8601 UTC timestamp. `validationStatus` is `"pass"` (only written on successful Layers 1–2).
+
+4. **Write atomically** using a project-local temp file (NOT `/tmp/` — Windows compat):
+
+   ```bash
+   <json content> > .arness/arn-spark-ensure-config.local.json.tmp
+   mv .arness/arn-spark-ensure-config.local.json.tmp .arness/arn-spark-ensure-config.local.json
+   ```
+
+   The `mv` is atomic on POSIX filesystems (Linux ext4, Mac APFS, Windows NTFS via Git Bash).
+
+5. **Verify** by reading the file back and confirming valid JSON. If the verify fails, surface as a warning but do not block — the next invocation will simply cache-miss.
+
+### When the cache invalidates
+
+- `pluginVersion` differs from current (plugin upgrade)
+- `schemaVersion` differs from current (cache schema bump — silently invalidates)
+- Any of the 7 fingerprints differs from current state
+
+All invalidation paths trigger a cache miss, which causes the entry-point to read the full ensure-config.md and re-run Layers 1–2 — at the end of which this Layer 3 step writes a new cache.
+
+---
+
+## Model profile field
+
+The `Spark agent model profile` field controls which Claude model each Arness Spark agent is dispatched on. It mirrors the structure of the Linting field flow used by Arness Code and reuses the same checksum + version-update machinery as report templates.
+
+### Field summary
+
+| Property | Value |
+|----------|-------|
+| Field name | `Spark agent model profile` |
+| Valid values | `all-opus` \| `balanced` \| `custom` |
+| Default on init | `all-opus` (preserves prior behavior) |
+| Where the choice lives | The field in `## Arness` records the user's choice; the actual model-per-agent map lives at `.arness/agent-models/spark.md`. |
+| Update policy | Reuses the project's `Template updates:` field (`ask` \| `auto` \| `manual`). If `Template updates:` is not present (Spark-only project), default to `ask`. |
+| Drift detection | SHA-256 checksum of `.arness/agent-models/spark.md` compared to the recorded checksum. Mismatch flips the field to `custom`. |
+| Custom diagnostic | When value is `custom`, missing-agent entries (against the canonical `all-opus.md` agent list) are surfaced as info-level diagnostics. |
+| User example | The arness repo's own `## Arness` block uses `Template path: .arness/templates`, `Template version: 2.3.0`, `Template updates: ask`. The model-profile field is appended in the same `- **Field name:** value` style. |
+
+### Profile selection procedure
+
+This procedure is the single source of truth for the prompt + write + copy + checksum flow. It is invoked from two places:
+- `arn-spark-init` ("Choose model profile" step), and
+- `arn-spark-ensure-config` Layer 2c (when the field is missing).
+
+Both call sites must read this section and follow it verbatim — do NOT duplicate the AskUserQuestion + write + copy + checksum logic at the call sites.
+
+**Steps:**
+
+1. **Cross-plugin default suggestion.** Before asking, read the project's CLAUDE.md `## Arness` block. If a sibling plugin's profile field (`Code agent model profile:` or `Infra agent model profile:`) is set to `all-opus` or `balanced`, suggest that value as the default in the AskUserQuestion options ordering (the recommended/default option goes first, with `(Recommended)` appended). If both siblings are set to different values, prefer the most recently written field; if neither is set, the default is `all-opus`.
+
+2. **Ask the user.** Ask (using `AskUserQuestion`):
+
+   > **Choose model profile for arn-spark agents**
+   > 1. **all-opus (Recommended)** — Every agent uses Opus. Maximum quality, maximum cost. (Current behavior.)
+   > 2. **balanced** — Opus for heavy reasoning, Sonnet for operational work. Lower cost, similar quality on routine tasks.
+
+   The label `(Recommended)` is appended to the suggested default (which may be `balanced` if a sibling plugin chose `balanced`). The recommended option appears first in the option list.
+
+3. **Write the field.** Append `- **Spark agent model profile:** <choice>` to the `## Arness` block in CLAUDE.md, using the existing field-write idiom (preserve all other fields, replace the single field if it already exists).
+
+4. **Copy the preset.** Create `.arness/agent-models/` if it does not exist (`mkdir -p .arness/agent-models`). Copy `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-init/references/agent-models-presets/<choice>.md` to `.arness/agent-models/spark.md`.
+
+5. **Record the checksum.** Compute the SHA-256 checksum of the copied file via Bash:
+   ```bash
+   sha256sum .arness/agent-models/spark.md 2>/dev/null || shasum -a 256 .arness/agent-models/spark.md
+   ```
+   Read or create `.arness/agent-models/.checksums.json`. Add or update the entry for `spark.md`:
+   ```json
+   {
+     "spark.md": {
+       "sha256": "<hex digest>",
+       "profile": "<choice>",
+       "version": "<version from the preset's # Version: header>"
+     }
+   }
+   ```
+   Preserve any sibling entries (`code.md`, `infra.md`) already present in `.checksums.json` — those belong to the other plugins and are managed by their own ensure-config flows.
+
+6. **Inform the user** with a one-line confirmation: `"Set Spark agent model profile to <choice>. Wrote .arness/agent-models/spark.md (sha256: <first-8-chars>...)."`
+
+### Drift detection (Layer 2c integration)
+
+Layer 2c runs the following whenever the field is present:
+
+1. **Checksum check.** Compute the current sha256 of `.arness/agent-models/spark.md` and compare to the recorded checksum in `.arness/agent-models/.checksums.json`. If they differ, flip the field to `custom` (one-line user message; do NOT overwrite the user's file).
+2. **Version check** (only when value is `all-opus` or `balanced` and checksums match): compare the `# Version:` header in the user's `.arness/agent-models/spark.md` against the upstream preset at `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-init/references/agent-models-presets/<value>.md`. On mismatch, apply the `Template updates:` policy (reuse `${CLAUDE_PLUGIN_ROOT}/skills/arn-code-save-plan/references/template-versioning.md`).
+3. **Custom diagnostic** (only when value is `custom`): read the canonical agent list from `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-init/references/agent-models-presets/all-opus.md` and surface info-level diagnostics for any canonical agent missing from the user's file.
 
 ---
 
@@ -274,3 +369,26 @@ If any are missing:
 6. **Profile data is non-sensitive** (role, technology preferences — no credentials or secrets). The `.claude/*.local.md` gitignore pattern protects against accidental commits of the project-level override while keeping `.claude/settings.json` committable for team sharing.
 7. **Folder preference coordination:** When setting `Folder preference`, this value is shared across all three plugins. If another plugin already set it, respect that value.
 8. **Discover resilience:** `arn-spark-discover` has "Prerequisites: None" in its design. If ensure-config encounters any error during Layer 2 (e.g., no writable directory, no CLAUDE.md), log the issue silently and let the original skill proceed. The profile (Layer 1) should still be captured if possible since it lives at `~/.arness/` which is always writable.
+
+---
+
+## Dispatch convention (agent model lookup)
+
+Every skill in this plugin that dispatches a subagent via the Task tool consults a per-plugin model profile to decide which model the agent runs on. The profile lives at `.arness/agent-models/spark.md` (project-relative, NOT plugin-relative — this path is project-rooted while plugin assets use `${CLAUDE_PLUGIN_ROOT}` per Pattern 8 in INTRODUCTION.md). The file is created during init and is one of the presets shipped under `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-init/references/agent-models-presets/`.
+
+### Lookup procedure (apply at every dispatch site)
+
+1. **Read `.arness/agent-models/spark.md`** (project-relative).
+2. **If the file is missing or unparseable:** omit the `model:` parameter when invoking the Task tool. The agent's frontmatter default (`opus`) applies. Do not surface an error — fallback is silent.
+3. **Look up the agent's name** (e.g., `arn-spark-doctor`, `arn-spark-product-strategist`) in the file's mapping.
+4. **If the agent name is found:** pass the mapped value (e.g., `opus`, `sonnet`, `haiku`) as the Task tool's `model` parameter. This overrides the agent's `model:` frontmatter.
+5. **If the agent name is NOT found in the file:** omit the `model:` parameter — frontmatter fallback applies. This keeps user-edited `custom` profiles forward-compatible: agents added to the plugin after the user customized their profile still run on their frontmatter default (`opus`) until the user adds them to the file.
+6. **Multi-agent parallel dispatches:** apply the lookup to each agent independently. A single instruction that spawns three agents in parallel produces three independent lookups, each potentially passing a different `model:` value.
+7. **Resume-mode dispatches** (calls that pass an existing agent ID via the Task tool's `resume` parameter): do NOT consult the profile. Resume calls inherit the model from the original invocation. Dispatch sites that resume an existing agent do not include the model-lookup phrasing.
+
+### Why this design
+
+- **Native Task tool support.** The Task tool's `model:` parameter takes precedence over agent frontmatter (Pattern 2 in INTRODUCTION.md). No wrapper or shim is needed.
+- **Self-documenting.** Every dispatch site explicitly references this convention, so the lookup behavior is visible at the point of dispatch rather than buried in a global default. A static grep for `via the Task tool` confirms coverage.
+- **Graceful degradation.** Missing file, missing agent entry, and unparseable content all fall back to frontmatter — there is no failure mode where dispatch hangs or errors on a config issue.
+- **Single source of truth.** `.arness/agent-models/spark.md` is the only place a user edits to change behavior across all arn-spark dispatches. The file is template-managed (Pattern 6) so version bumps, drift detection, and the `Template updates: ask | auto | manual` policy all apply.

--- a/plugins/arn-spark/skills/arn-spark-ensure-config/references/step-0-fast-path.md
+++ b/plugins/arn-spark/skills/arn-spark-ensure-config/references/step-0-fast-path.md
@@ -1,0 +1,25 @@
+# Arness Spark Ensure-Config — Step 0 Fast-Path
+
+This is the **first read** for entry-point skills' Step 0. It runs a shell-only cache check; if the cache is valid, the entry-point can skip reading the full `references/ensure-config.md`. On cache miss, falls through to the full validation flow.
+
+## Procedure
+
+1. **Run the cache check** via Bash:
+
+   ```
+   bash ${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-ensure-config/scripts/cache-check.sh
+   ```
+
+2. **If exit 0 (cache hit):**
+   - Emit a one-line status to the user: `Ensure-config: cache valid (arn-spark, last validated <duration> ago)`. Read the `validatedAt` timestamp from `.arness/arn-spark-ensure-config.local.json` to format the duration; if reading fails, just say "cache valid".
+   - Return immediately. The entry-point skill's own workflow proceeds with no further config work.
+   - **Do NOT read `references/ensure-config.md`** — that is the whole point of the fast path.
+
+3. **If exit non-zero (cache miss):**
+   - The script's stderr output includes the reason (e.g., `cache miss: pluginVersion changed`, `cache miss: fingerprint claudeMdArnessSection changed`). Surface it as an info-level note: `Ensure-config: cache miss (<reason>) — running full validation.`
+   - **Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-ensure-config/references/ensure-config.md`** and follow ALL its instructions.
+   - At the end of successful validation, the ensure-config.md flow's "Cache Write" step writes the new `.arness/arn-spark-ensure-config.local.json` per the cache schema documented inline there.
+
+## Cross-platform notes
+
+The cache-check script works on Linux, Mac, and Windows-via-Git-Bash. It requires `bash`, `sha256sum` or `shasum`, `awk`, `grep`, `cat`, and `jq`. The `gh` CLI is optional (used only for GitHub label count verification). If any required tool is missing, the script exits non-zero and full validation runs as the fallback.

--- a/plugins/arn-spark/skills/arn-spark-ensure-config/scripts/cache-check.sh
+++ b/plugins/arn-spark/skills/arn-spark-ensure-config/scripts/cache-check.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# arn-spark-ensure-config cache-check.sh
+#
+# Returns exit 0 when the cache at .arness/arn-spark-ensure-config.local.json
+# is valid (all fingerprints match current state). Returns non-zero with a
+# stderr reason on miss.
+#
+# Cross-platform: works on Linux, Mac, and Windows-via-Git-Bash.
+# Required tools: bash, sha256sum or shasum, awk, grep, mv, cat, jq.
+# Optional tool: gh (only used for GitHub label count check).
+
+set -u
+
+PLUGIN_NAME="arn-spark"
+SHORT_NAME="spark"
+SCHEMA_VERSION=1
+EXPECTED_LABELS_COUNT=7
+CACHE_FILE=".arness/${PLUGIN_NAME}-ensure-config.local.json"
+
+# --- Helper: fail fast with reason ---
+miss() {
+  echo "cache miss: $1" >&2
+  exit 1
+}
+
+# --- Helper: cross-platform SHA-256 ---
+hash_str() {
+  local data="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$data" | sha256sum | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$data" | shasum -a 256 | awk '{print $1}'
+  else
+    echo "ERROR: neither sha256sum nor shasum available" >&2
+    exit 2
+  fi
+}
+
+hash_file() {
+  local path="$1"
+  if [ ! -f "$path" ]; then
+    echo "MISSING"
+    return 0
+  fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$path" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$path" | awk '{print $1}'
+  else
+    echo "ERROR: neither sha256sum nor shasum available" >&2
+    exit 2
+  fi
+}
+
+# --- 1. Cache file present? ---
+[ -f "$CACHE_FILE" ] || miss "no cache file at $CACHE_FILE"
+
+# --- 2. jq available for parsing? ---
+command -v jq >/dev/null 2>&1 || miss "jq not available (required for cache parsing)"
+
+# --- 3. Schema version matches? ---
+cached_schema=$(jq -r '.schemaVersion // empty' "$CACHE_FILE" 2>/dev/null)
+[ "$cached_schema" = "$SCHEMA_VERSION" ] || miss "schemaVersion mismatch (cache: ${cached_schema:-empty}, expected: $SCHEMA_VERSION)"
+
+# --- 4. Plugin version matches? ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+MARKETPLACE_JSON="$(cd "$PLUGIN_ROOT/.." && pwd)/.claude-plugin/marketplace.json"
+
+if [ -f "$MARKETPLACE_JSON" ]; then
+  current_version=$(jq -r --arg name "$PLUGIN_NAME" '.plugins[] | select(.name==$name) | .version' "$MARKETPLACE_JSON" 2>/dev/null)
+  cached_version=$(jq -r '.pluginVersion // empty' "$CACHE_FILE")
+  if [ -n "$current_version" ] && [ "$current_version" != "$cached_version" ]; then
+    miss "pluginVersion changed (cache: $cached_version, current: $current_version)"
+  fi
+fi
+
+# --- 5. Compute current fingerprints ---
+if [ -f "CLAUDE.md" ]; then
+  arness_section=$(awk '/^## Arness$/{flag=1;next} /^## /{flag=0} flag' CLAUDE.md)
+  current_arness_section_hash=$(hash_str "$arness_section")
+else
+  current_arness_section_hash="MISSING"
+fi
+
+current_agent_models_hash=$(hash_file ".arness/agent-models/${SHORT_NAME}.md")
+current_agent_models_checksums_hash=$(hash_file ".arness/agent-models/.checksums.json")
+current_templates_checksums_hash=$(hash_file ".arness/templates/.checksums.json")
+current_user_profile_hash=$(hash_file "$HOME/.arness/user-profile.yaml")
+current_profile_override_hash=$(hash_file ".claude/arness-profile.local.md")
+current_gitignore_hash=$(hash_file ".gitignore")
+
+# --- 6. Compare against cache ---
+# Use parallel indexed arrays (bash 3.2 compatible — Mac's default /bin/bash is 3.2,
+# associative arrays via 'declare -A' are bash 4+ only).
+KEYS=(claudeMdArnessSection agentModelsCodeMd agentModelsChecksums templatesChecksums userProfile profileOverride gitignoreContent)
+VALUES=(
+  "$current_arness_section_hash"
+  "$current_agent_models_hash"
+  "$current_agent_models_checksums_hash"
+  "$current_templates_checksums_hash"
+  "$current_user_profile_hash"
+  "$current_profile_override_hash"
+  "$current_gitignore_hash"
+)
+
+i=0
+while [ $i -lt ${#KEYS[@]} ]; do
+  key="${KEYS[$i]}"
+  current="${VALUES[$i]}"
+  cached=$(jq -r ".fingerprints.${key} // empty" "$CACHE_FILE")
+  if [ "$cached" != "$current" ]; then
+    miss "fingerprint $key changed (cache: ${cached:0:16}..., current: ${current:0:16}...)"
+  fi
+  i=$((i + 1))
+done
+
+# --- 7. GitHub labels check (only if Platform=github AND gh available) ---
+if [ -f "CLAUDE.md" ]; then
+  platform=$(grep -E '^- \*\*Platform:\*\*' CLAUDE.md 2>/dev/null | head -1 | sed -E 's/.*Platform:\*\*\s*//')
+  if [ "$platform" = "github" ] && command -v gh >/dev/null 2>&1; then
+    label_count=$(gh label list --json name --jq '.[].name' 2>/dev/null | grep -c '^arness-' || echo 0)
+    if [ "$label_count" != "$EXPECTED_LABELS_COUNT" ]; then
+      miss "GitHub arness-* label count is $label_count, expected $EXPECTED_LABELS_COUNT"
+    fi
+  fi
+fi
+
+exit 0

--- a/plugins/arn-spark/skills/arn-spark-feature-extract/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-feature-extract/SKILL.md
@@ -110,7 +110,7 @@ Note which artifacts were available and which were missing. Present the artifact
 
 ### Step 2: Extract Features with Experts
 
-Invoke the `arn-spark-product-strategist` agent with:
+Invoke the `arn-spark-product-strategist` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 - All loaded artifacts
 - Request to extract and categorize features from the artifacts
@@ -130,7 +130,7 @@ The agent returns:
 - Scope observations (features that might be scope creep, features that seem missing)
 - Sizing warnings (features that seem too large or too thin)
 
-Then invoke `arn-spark-ux-specialist` with:
+Then invoke the `arn-spark-ux-specialist` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 - The product strategist's feature list
 - User journey definitions and journey screenshots from the clickable prototype
@@ -177,12 +177,12 @@ After merging both expert outputs, scan for gaps -- areas where the consolidated
    - What each expert said (or didn't say) about it
    - Why it matters for downstream spec writing
 
-2. Invoke `arn-spark-product-strategist` with:
+2. Invoke the `arn-spark-product-strategist` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
    - The gap summary
    - The full consolidated feature list for context
    - Instruction: "For each gap, propose a solution or alternative from the product perspective. Consider: should the feature be deferred, split, merged, or redefined? What is the minimal viable scope? If journey coverage is missing, which journeys should the feature map to?"
 
-3. Invoke `arn-spark-ux-specialist` with:
+3. Invoke the `arn-spark-ux-specialist` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
    - The gap summary
    - The product strategist's proposed solutions
    - The full consolidated feature list

--- a/plugins/arn-spark/skills/arn-spark-init/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-init/SKILL.md
@@ -210,6 +210,24 @@ Downstream skills check these flags — not MCP availability — to decide wheth
 
 ---
 
+### Step 3.6: Choose Model Profile for arn-spark Agents
+
+Run the **Profile selection** procedure documented in `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-ensure-config/references/step-0-fast-path.md` under the "Model profile field" section. That procedure is the single source of truth for the prompt + write + copy + checksum flow — do NOT duplicate the AskUserQuestion or file-copy logic here.
+
+The procedure performs (in order):
+1. Cross-plugin default suggestion (read sibling plugin profile fields if present in the existing `## Arness` block — e.g., if the user previously chose `balanced` for arn-code, suggest `balanced` here too)
+2. AskUserQuestion with title "Choose model profile for arn-spark agents" and two options: `all-opus` (default unless a sibling chose `balanced`) and `balanced`
+3. Append `- **Spark agent model profile:** <choice>` to the `## Arness` block
+4. `mkdir -p .arness/agent-models/` then copy `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-init/references/agent-models-presets/<choice>.md` to `.arness/agent-models/spark.md`
+5. Compute SHA-256 and record it in `.arness/agent-models/.checksums.json` along with the profile name and version
+6. Inform the user with a one-line confirmation
+
+The field write in step 3 of the procedure is captured for the CLAUDE.md write in Step 4 of this init flow — write the chosen value to a holding variable and let Step 4 emit it inline with all other fields. The preset copy + checksum (steps 4-5 of the procedure) happen here regardless of when the CLAUDE.md write is performed.
+
+Record the chosen profile for the config write in Step 4.
+
+---
+
 ### Step 4: Persist Configuration to CLAUDE.md
 
 Write (or update) the `## Arness` section in the project's CLAUDE.md:
@@ -223,6 +241,7 @@ Write (or update) the `## Arness` section in the project's CLAUDE.md:
 - **Spikes directory:** [chosen-path]
 - **Visual grounding directory:** [chosen-path]
 - **Reports directory:** [chosen-path]
+- **Spark agent model profile:** all-opus | balanced | custom
 - **Git:** yes | no
 - **Platform:** github | bitbucket | none
 - **Issue tracker:** github | jira | none

--- a/plugins/arn-spark/skills/arn-spark-init/references/agent-models-presets/all-opus.md
+++ b/plugins/arn-spark/skills/arn-spark-init/references/agent-models-presets/all-opus.md
@@ -1,0 +1,23 @@
+# Profile: all-opus
+# Version: 1.0.0
+
+arn-spark-brand-strategist: opus
+arn-spark-dev-env-builder: opus
+arn-spark-doctor: opus
+arn-spark-forensic-investigator: opus
+arn-spark-marketing-pm: opus
+arn-spark-market-researcher: opus
+arn-spark-persona-architect: opus
+arn-spark-persona-impersonator: opus
+arn-spark-product-strategist: opus
+arn-spark-prototype-builder: opus
+arn-spark-scaffolder: opus
+arn-spark-spike-runner: opus
+arn-spark-style-capture: opus
+arn-spark-tech-evaluator: opus
+arn-spark-ui-interactor: opus
+arn-spark-use-case-writer: opus
+arn-spark-ux-judge: opus
+arn-spark-ux-specialist: opus
+arn-spark-visual-sketcher: opus
+arn-spark-visual-test-engineer: opus

--- a/plugins/arn-spark/skills/arn-spark-init/references/agent-models-presets/balanced.md
+++ b/plugins/arn-spark/skills/arn-spark-init/references/agent-models-presets/balanced.md
@@ -1,0 +1,23 @@
+# Profile: balanced
+# Version: 1.0.0
+
+arn-spark-brand-strategist: opus
+arn-spark-dev-env-builder: sonnet
+arn-spark-doctor: sonnet
+arn-spark-forensic-investigator: opus
+arn-spark-marketing-pm: opus
+arn-spark-market-researcher: opus
+arn-spark-persona-architect: opus
+arn-spark-persona-impersonator: sonnet
+arn-spark-product-strategist: opus
+arn-spark-prototype-builder: opus
+arn-spark-scaffolder: sonnet
+arn-spark-spike-runner: sonnet
+arn-spark-style-capture: sonnet
+arn-spark-tech-evaluator: opus
+arn-spark-ui-interactor: sonnet
+arn-spark-use-case-writer: sonnet
+arn-spark-ux-judge: opus
+arn-spark-ux-specialist: sonnet
+arn-spark-visual-sketcher: sonnet
+arn-spark-visual-test-engineer: sonnet

--- a/plugins/arn-spark/skills/arn-spark-naming/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-naming/SKILL.md
@@ -69,7 +69,7 @@ If resume: read the brief, detect which sections contain "-- Pending --" or are 
 
 ## Step 1: Strategic Foundation (Brand DNA)
 
-Invoke `arn-spark-brand-strategist` in `brand-dna` mode with:
+Invoke the `arn-spark-brand-strategist` agent in `brand-dna` mode via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - Product context (from product-concept.md or user input)
 - Competitive landscape (from product concept, or agent will research via WebSearch)
 - Target market
@@ -126,7 +126,7 @@ Update `naming-brief.md` with Creative Sprint Results section (generation stats,
 Load the scoring methodology:
 > Read `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-naming/references/naming-methodology.md`
 
-Invoke `arn-spark-brand-strategist` in `scoring` mode with: full candidate list, user-starred favorites, dead directions.
+Invoke the `arn-spark-brand-strategist` agent in `scoring` mode via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context: full candidate list, user-starred favorites, dead directions.
 
 **Pass 1:** Agent filters 200+ candidates to 30-40 by removing obvious duds (unpronounceable, too long, too similar, offensive, dead directions). User-starred names always survive Pass 1.
 
@@ -193,7 +193,7 @@ Load trademark database reference:
 
 ### 4c — Linguistic Screening
 
-Invoke `arn-spark-brand-strategist` in `linguistic-screening` mode with: finalist names, target market, relevant languages (mapped from target market per the agent's language mapping).
+Invoke the `arn-spark-brand-strategist` agent in `linguistic-screening` mode via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context: finalist names, target market, relevant languages (mapped from target market per the agent's language mapping).
 
 The agent checks each name for: negative meanings, phonetic conflicts, cultural associations, and slang issues. Uses WebSearch for verification of uncertain findings.
 

--- a/plugins/arn-spark/skills/arn-spark-report/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-report/SKILL.md
@@ -74,7 +74,7 @@ If GitHub access is not available, offer an alternative: generate the diagnostic
 
 ### Step 4: Invoke arn-spark-doctor
 
-Spawn the `arn-spark-doctor` agent via the Task tool with:
+Spawn the `arn-spark-doctor` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - The user's description of the issue
 - Project root path
 - `## Arness` config content (or "not configured")

--- a/plugins/arn-spark/skills/arn-spark-scaffold/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-scaffold/SKILL.md
@@ -132,7 +132,7 @@ Record all UI toolkit decisions for the scaffolder.
 
 ### Step 3: Invoke Scaffolder
 
-Invoke the `arn-spark-scaffolder` agent with:
+Invoke the `arn-spark-scaffolder` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 - All stack decisions from Step 1 (framework, UI, build, package manager, test, linter)
 - All UI toolkit decisions from Step 2 (CSS framework, component library, icon library)

--- a/plugins/arn-spark/skills/arn-spark-spike/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-spike/SKILL.md
@@ -103,7 +103,7 @@ Wait for user approval or adjustments before running each spike. The user may wa
 
 For each approved spike, in order:
 
-1. Invoke the `arn-spark-spike-runner` agent (foreground, not background) with:
+1. Invoke the `arn-spark-spike-runner` agent via the Task tool (foreground, not background), passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
    - Risk description and context
    - Validation criteria
    - Project context (stack, existing scaffold location)

--- a/plugins/arn-spark/skills/arn-spark-static-prototype-teams/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-static-prototype-teams/SKILL.md
@@ -240,7 +240,7 @@ For each cycle:
 
 #### 5a: Build
 
-Invoke the `arn-spark-prototype-builder` agent with:
+Invoke the `arn-spark-prototype-builder` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - **Showcase mode:** true
 - **Style brief:** toolkit configuration section
 - **Component list:** components from the criteria + style brief
@@ -255,7 +255,7 @@ Mark the Build task as in_progress before invoking, completed after.
 
 #### 5b: Capture Screenshots
 
-Invoke the `arn-spark-style-capture` agent with:
+Invoke the `arn-spark-style-capture` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - **URL:** the URL serving the showcase (from the running prototype)
 - **Output path:** `prototypes/static/v[N]/screenshots/`
 
@@ -388,7 +388,7 @@ Mark the Debate review task as in_progress before Phase 1, completed after all p
 
 ### Step 6: Judge Review
 
-Invoke the `arn-spark-ux-judge` agent with:
+Invoke the `arn-spark-ux-judge` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - **Review mode:** `static` -- the judge reviews screenshots and files (there is nothing interactive to navigate in a static showcase)
 - **Prototype artifacts:** paths to the latest version's showcase files and screenshots
 - **Criteria list:** from `prototypes/criteria.md`

--- a/plugins/arn-spark/skills/arn-spark-static-prototype-teams/references/debate-protocol.md
+++ b/plugins/arn-spark/skills/arn-spark-static-prototype-teams/references/debate-protocol.md
@@ -149,7 +149,7 @@ When Agent Teams is not enabled, the skill simulates the debate with 3 sequentia
 
 **Invocation 1 -- Product Strategist Phase 1:**
 
-Invoke `arn-spark-product-strategist` with:
+Invoke the `arn-spark-product-strategist` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - Screenshots from capture step
 - All criteria with descriptions, scoring scale, and threshold
 - Style brief, product concept, visual grounding assets (with category context)
@@ -159,7 +159,7 @@ Invoke `arn-spark-product-strategist` with:
 
 **Invocation 2 -- UX Specialist Phase 1 + Phase 2 Combined:**
 
-Invoke `arn-spark-ux-specialist` with:
+Invoke the `arn-spark-ux-specialist` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - Same inputs as Invocation 1
 - The strategist's file path to read: `prototypes/static/reviews/round-N-strategist-review.md`
 - File path to write to: `prototypes/static/reviews/round-N-ux-review.md`
@@ -167,7 +167,7 @@ Invoke `arn-spark-ux-specialist` with:
 
 **Invocation 3 -- Product Strategist Phase 2:**
 
-Invoke `arn-spark-product-strategist` with:
+Invoke the `arn-spark-product-strategist` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - The UX specialist's file path to read: `prototypes/static/reviews/round-N-ux-review.md`
 - Expert visual review template path
 - File path to write to: `prototypes/static/reviews/round-N-strategist-cross-review.md`

--- a/plugins/arn-spark/skills/arn-spark-static-prototype/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-static-prototype/SKILL.md
@@ -159,7 +159,7 @@ For each cycle:
 
 #### 4a: Build
 
-Invoke the `arn-spark-prototype-builder` agent with:
+Invoke the `arn-spark-prototype-builder` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - **Showcase mode:** true
 - **Style brief:** toolkit configuration section
 - **Component list:** components from the criteria + style brief
@@ -174,7 +174,7 @@ Mark the Build task as in_progress before invoking, completed after.
 
 #### 4b: Capture Screenshots
 
-Invoke the `arn-spark-style-capture` agent with:
+Invoke the `arn-spark-style-capture` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - **URL:** the URL serving the showcase (from the running prototype)
 - **Output path:** `prototypes/static/v[N]/screenshots/`
 
@@ -213,7 +213,7 @@ For each criterion, use the LOWER of the two expert scores as the combined score
 
 ### Step 5: Judge Review
 
-Invoke the `arn-spark-ux-judge` agent with:
+Invoke the `arn-spark-ux-judge` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - **Review mode:** `static` -- the judge reviews screenshots and files (there is nothing interactive to navigate in a static showcase)
 - **Prototype artifacts:** paths to the latest version's showcase files and screenshots
 - **Criteria list:** from `prototypes/criteria.md`

--- a/plugins/arn-spark/skills/arn-spark-stress-competitive/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-stress-competitive/SKILL.md
@@ -71,7 +71,7 @@ Build the initial competitor list from the competitive landscape section of the 
 
 ### Step 3: Deep Competitive Research
 
-Invoke `arn-spark-market-researcher` in **deep-analysis mode** with:
+Invoke the `arn-spark-market-researcher` agent in **deep-analysis mode** via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 --- PRODUCT CONCEPT (relevant sections) ---
 [Extract and pass: Vision, Core Experience, Product Pillars, Competitive Landscape, Scope Boundaries, Target Platforms. Do not pass the full document — focus on sections relevant to competitive analysis.]

--- a/plugins/arn-spark/skills/arn-spark-stress-interview/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-stress-interview/SKILL.md
@@ -73,7 +73,7 @@ Read the product concept from `<vision-dir>/product-concept.md`. Extract:
 
 Select 3 persona moulds from the product concept. If more than 3 moulds exist, select the 3 most diverse in adoption posture and technical sophistication.
 
-For each mould, invoke `arn-spark-persona-architect` in **instantiation mode** with:
+For each mould, invoke the `arn-spark-persona-architect` agent in **instantiation mode** via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 --- PERSONA MOULD ---
 [full abstracted profile from product concept]
@@ -106,7 +106,7 @@ Run interviews in 3 waves. Each wave runs one phase for all 3 personas in parall
 
 Run all 3 personas' Phase 1 interviews in parallel. For each persona in parallel:
 
-Invoke `arn-spark-product-strategist` with:
+Invoke the `arn-spark-product-strategist` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 --- PRODUCT CONCEPT ---
 [full product concept]
@@ -120,7 +120,7 @@ Phase 1 goal: formulate 2-3 questions that probe problem recognition without rev
 [full cast persona profile]
 --- END PERSONA PROFILE ---
 
-Then invoke `arn-spark-persona-impersonator` with:
+Then invoke the `arn-spark-persona-impersonator` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 --- PERSONA PROFILE ---
 [full cast persona profile]
@@ -170,7 +170,7 @@ Record the full response for each persona.
 
 ### Step 5: Synthesize Findings
 
-After all 9 interviews are complete, invoke `arn-spark-product-strategist` with:
+After all 9 interviews are complete, invoke the `arn-spark-product-strategist` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 --- PRODUCT CONCEPT ---
 [full product concept]

--- a/plugins/arn-spark/skills/arn-spark-stress-interview/references/persona-casting-spec.md
+++ b/plugins/arn-spark/skills/arn-spark-stress-interview/references/persona-casting-spec.md
@@ -120,7 +120,7 @@ The interview skill uses the following process to generate cast personas:
 
 1. **Read persona moulds** from the product concept's Target Personas section
 2. **Select 3 moulds** (or use all if 3 or fewer exist). If more than 3 moulds exist, select the 3 that are most diverse in their adoption posture and technical sophistication.
-3. **For each mould, invoke `arn-spark-persona-architect` in instantiation mode** with:
+3. **For each mould, invoke the `arn-spark-persona-architect` agent in instantiation mode** via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
    - The mould definition (abstracted profile)
    - The casting overlay specification (from this document)
    - The product concept summary (for domain grounding)

--- a/plugins/arn-spark/skills/arn-spark-stress-premortem/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-stress-premortem/SKILL.md
@@ -72,7 +72,7 @@ Read the product concept from `<vision-dir>/product-concept.md`. Extract:
 
 ### Step 3: Invoke Forensic Investigator
 
-Invoke `arn-spark-forensic-investigator` with:
+Invoke the `arn-spark-forensic-investigator` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 --- PRODUCT CONCEPT ---
 [full product concept document]

--- a/plugins/arn-spark/skills/arn-spark-stress-prfaq/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-stress-prfaq/SKILL.md
@@ -72,7 +72,7 @@ Read the product concept from `<vision-dir>/product-concept.md`. Extract:
 
 ### Step 3: Phase 1 -- Draft
 
-Invoke `arn-spark-marketing-pm` in **draft mode** with:
+Invoke the `arn-spark-marketing-pm` agent in **draft mode** via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 --- PRODUCT CONCEPT ---
 [full product concept document]
@@ -104,7 +104,7 @@ If the draft is too thin or generic, retry with more specific context:
 
 ### Step 4: Phase 2 -- Critique
 
-Invoke `arn-spark-marketing-pm` in **critique mode** with:
+Invoke the `arn-spark-marketing-pm` agent in **critique mode** via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 --- PRODUCT CONCEPT ---
 [full product concept document -- same as Phase 1]

--- a/plugins/arn-spark/skills/arn-spark-stress-prfaq/references/prfaq-workflow.md
+++ b/plugins/arn-spark/skills/arn-spark-stress-prfaq/references/prfaq-workflow.md
@@ -21,7 +21,7 @@ Produce a genuinely compelling press release and FAQ that represents the best po
 
 ### Agent Invocation
 
-Invoke `arn-spark-marketing-pm` in **draft mode** with:
+Invoke the `arn-spark-marketing-pm` agent in **draft mode** via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - Full product concept
 - Product pillars (to anchor messaging)
 - Operating mode: `draft`
@@ -72,7 +72,7 @@ Adversarially evaluate the draft to find every place where the messaging makes a
 
 ### Agent Invocation
 
-Invoke `arn-spark-marketing-pm` in **critique mode** with:
+Invoke the `arn-spark-marketing-pm` agent in **critique mode** via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - Full product concept (same as Phase 1)
 - Product pillars (same as Phase 1)
 - Operating mode: `critique`

--- a/plugins/arn-spark/skills/arn-spark-style-explore/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-style-explore/SKILL.md
@@ -136,7 +136,7 @@ Options:
 | Hand-drawn wireframes | User provides photos → save to `[visual-grounding]/designs/` |
 | Brand assets (logos, guidelines) | User provides files → save to `[visual-grounding]/brand/` |
 
-**If the user provides one or more URLs:** Invoke the `arn-spark-style-capture` agent with the URLs and save screenshots to the visual grounding directory (under `references/`). If the agent reports Playwright is not available, inform the user:
+**If the user provides one or more URLs:** Invoke the `arn-spark-style-capture` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback), with the URLs and save screenshots to the visual grounding directory (under `references/`). If the agent reports Playwright is not available, inform the user:
 
 "Playwright is not installed in this environment, so I cannot automatically capture that URL. You can either:
 1. Install Playwright (`npm install -D playwright && npx playwright install chromium`) and try again
@@ -147,7 +147,7 @@ If capture succeeds, use the agent's extracted design characteristics (colors, t
 
 ### Step 2: Initial Style Proposal
 
-Invoke the `arn-spark-ux-specialist` agent (greenfield agent) with:
+Invoke the `arn-spark-ux-specialist` agent (greenfield agent) via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 
 - The user's style description or preferences
 - Product concept context (target users, product personality)

--- a/plugins/arn-spark/skills/arn-spark-use-cases-teams/references/debate-protocol.md
+++ b/plugins/arn-spark/skills/arn-spark-use-cases-teams/references/debate-protocol.md
@@ -164,7 +164,7 @@ When Agent Teams is not enabled, the skill simulates the debate with 3 sequentia
 
 **Invocation 1 — Business Reviewer Phase 1:**
 
-Invoke `arn-spark-product-strategist` with:
+Invoke the `arn-spark-product-strategist` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - All use case content (read each file and provide the content)
 - Product concept for context
 - Actor catalog
@@ -177,7 +177,7 @@ The strategist writes its Phase 1 review to the file.
 
 **Invocation 2 — Flow Reviewer Phase 1 + Phase 2 Combined:**
 
-Invoke `arn-spark-ux-specialist` with:
+Invoke the `arn-spark-ux-specialist` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - All use case content
 - Product concept for context
 - Existing prototype screens (if available)
@@ -191,7 +191,7 @@ The UX specialist reads the business review file and writes its combined review 
 
 **Invocation 3 — Business Reviewer Phase 2:**
 
-Invoke `arn-spark-product-strategist` with:
+Invoke the `arn-spark-product-strategist` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - The flow reviewer's file path to read: `[use-cases-dir]/reviews/round-N-flow-review.md`
 - Expert review template path: `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-use-cases/references/expert-review-template.md`
 - File path to write to: `[use-cases-dir]/reviews/round-N-business-cross-review.md`

--- a/plugins/arn-spark/skills/arn-spark-use-cases/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-use-cases/SKILL.md
@@ -108,13 +108,13 @@ Load the product concept and perform an initial extraction of actors and use cas
 
 #### 2b: Expert Use Case Discovery
 
-Invoke `arn-spark-product-strategist` with:
+Invoke the `arn-spark-product-strategist` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - The product concept document
 - The initial actor and use case extraction from Step 2a
 - Product pillars (if present in the product concept)
 - Instructions: "Review this initial actor and use case catalog from a business perspective. Identify: (1) Missing actors — are there stakeholders, external systems, or participant roles not captured? (2) Missing use cases — are there business processes, capabilities described in the product concept, or product pillar implications that do not have a corresponding use case? (3) Priority concerns — are any use cases mislabeled as must-have or should-have? (4) Scope concerns — are any proposed use cases out of scope for v1? Do not draft use case details — just identify what is missing or needs adjustment. Return a list of suggested additions and corrections."
 
-Then invoke `arn-spark-ux-specialist` with:
+Then invoke the `arn-spark-ux-specialist` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - The product concept document
 - The initial actor and use case extraction from Step 2a
 - Existing prototype screens (if available)
@@ -187,7 +187,7 @@ Draft use cases in parallel by invoking multiple `arn-spark-use-case-writer` age
 - **Existing prototype screens (if any):** paths to prototype directories
 - **Architecture vision (if available):** for system capability context
 
-After all parallel writers complete, invoke one final `arn-spark-use-case-writer` with:
+After all parallel writers complete, invoke one final `arn-spark-use-case-writer` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - **Index template:** `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-use-cases/references/use-case-index-template.md`
 - **Output directory:** `use-cases/`
 - **Product concept:** document path
@@ -203,7 +203,7 @@ Read the review protocol for the team process:
 
 Create the `[use-cases-dir]/reviews/` directory if it does not exist.
 
-Invoke `arn-spark-product-strategist` with:
+Invoke the `arn-spark-product-strategist` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - All drafted use case content (read each file and provide the content)
 - Product concept for context
 - Actor catalog
@@ -215,7 +215,7 @@ After the strategist completes, read the review file at the specified path to ex
 
 ### Step 5: UX Specialist Review (Batch)
 
-Invoke `arn-spark-ux-specialist` with:
+Invoke the `arn-spark-ux-specialist` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - All drafted use case content
 - Product concept for context
 - Existing prototype screens (if available)

--- a/plugins/arn-spark/skills/arn-spark-visual-readiness/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-visual-readiness/SKILL.md
@@ -144,7 +144,7 @@ For each qualifying layer:
 
 2. Determine the spike workspace: `[spikes-dir]/visual-readiness-spike-layer-[N]/`
 
-3. Invoke the `arn-spark-visual-test-engineer` agent (foreground, not background) with:
+3. Invoke the `arn-spark-visual-test-engineer` agent via the Task tool (foreground, not background), passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
    - Layer specification (name, capture approach, environment, scripts)
    - Stack details from the strategy document
    - Environment constraints
@@ -187,7 +187,7 @@ For each deferred layer that was validated (Validated or user-approved Partially
    a. Update the layer's `**Interaction:**` field from `static` to `journey` in CLAUDE.md
    b. Add `**Journey manifest:**` field with path `<baselines-dir>/layer-2/journey-manifest.json`
    c. Add `**Journey runner:**` field with path `scripts/journey-runner.<ext>` (`.ps1` for Windows, `.swift` or `.applescript` for macOS)
-   d. Invoke `arn-spark-visual-test-engineer` agent with:
+   d. Invoke the `arn-spark-visual-test-engineer` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
       - Journey schema reference: `${CLAUDE_PLUGIN_ROOT}/skills/arn-spark-visual-strategy/references/journey-schema.md`
       - Journey manifest output path: the path from step (b)
       - Target platform: detected from the layer's `**Environment:**` field

--- a/plugins/arn-spark/skills/arn-spark-visual-sketch/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-visual-sketch/SKILL.md
@@ -293,7 +293,7 @@ Wait for the user's feedback. The user may:
 
 When the user has selected a final direction:
 
-1. **Capture screenshots:** Invoke the `arn-spark-style-capture` agent with:
+1. **Capture screenshots:** Invoke the `arn-spark-style-capture` agent via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
    - URLs: the localhost URLs of each screen in the selected proposal (from the proposal's `proposal-manifest.json`)
    - Output path: `[visual-grounding]/designs/`
    - File naming: `visual-sketch-[screen-name].png` (e.g., `visual-sketch-dashboard.png`)

--- a/plugins/arn-spark/skills/arn-spark-visual-strategy/SKILL.md
+++ b/plugins/arn-spark/skills/arn-spark-visual-strategy/SKILL.md
@@ -224,7 +224,7 @@ For each layer:
 
 3. Determine the spike workspace: `[spikes-dir]/visual-strategy-spike-layer-[N]/`
 
-4. Invoke the `arn-spark-visual-test-engineer` agent (foreground, not background) with:
+4. Invoke the `arn-spark-visual-test-engineer` agent via the Task tool (foreground, not background), passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
    - Stack details (application type, framework, rendering context)
    - Layer specification (what approach to validate)
    - Environment constraints
@@ -260,7 +260,7 @@ The spike must validate journey readiness in addition to the standard Layer 2 sp
 
 ### Step 5: Generate Production Scripts
 
-After validating layers, invoke `arn-spark-visual-test-engineer` again (foreground) with:
+After validating layers, invoke the `arn-spark-visual-test-engineer` agent again (foreground) via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - Validated layer specifications and spike results
 - Full baseline image set (all screens, not just the POC subset)
 - Project structure and build configuration
@@ -276,7 +276,7 @@ Present the scripts to the user before writing to the project.
 
 ### Step 6: Set Up Baseline Images
 
-Invoke `arn-spark-visual-test-engineer` (foreground) with:
+Invoke the `arn-spark-visual-test-engineer` agent (foreground) via the Task tool, passing the model from `.arness/agent-models/spark.md` as the `model` parameter (see `plugins/arn-spark/skills/arn-spark-ensure-config/references/ensure-config.md` "Dispatch convention" for fallback). Context:
 - Prototype screenshot locations (from Step 3)
 - Baseline directory path (e.g., `visual-tests/baselines/`)
 - Naming convention from the capture script


### PR DESCRIPTION
## Summary

A batch of 4 features focused on Arness cost optimization and configurability. Cumulative impact: per-plugin agent model selection (potential ~30–50% cost reduction on the balanced profile), per-phase model upgrades when reasoning is warranted, configurable simplify dispatches, and a hash-based ensure-config cache that cuts ~95% of Step 0 token overhead on cache hits.

Shipped as 4 separate commits (one per feature) for clean blame/revert.

## Features (in commit order)

**1. `feat(arn-code,arn-spark,arn-infra): add per-plugin agent model profiles` (`af629a5`)**
Two presets per plugin (`all-opus`, `balanced`); ~80 dispatch sites pass `model:` looked up from `.arness/agent-models/<plugin>.md` via Task tool. New `Agent Model Profiles` section in repo CLAUDE.md. Init + ensure-config flows ask once.

**2. `feat(arn-code): configurable simplify reviewer + applier models` (`89c6ab4`)**
Splits the 3-axis simplify reviewers and the apply phase into 2 synthetic agent names (`arn-code-simplify-reviewer`, `arn-code-simplify-applier`). Apply phase extracted out of the orchestrator into an anonymous Agent dispatch so its model is also configurable. Default in `balanced`: reviewer=opus, applier=sonnet.

**3. `feat(arn-code): per-phase model upgrade for complex phases` (`bbc2018`)**
Planner emits per-phase `complexity` + `complexityRationale`. On `balanced`/`custom` profile, the plan presentation runs a two-tier preference gate (`pipeline.complex-phase-upgrade`) for an all-or-none Opus upgrade for complex phases. Override travels through PROGRESS_TRACKER and gets honored by 3 executor dispatch sites. Reviewers stay on configured tier.

**4. `feat(arn-code,arn-spark,arn-infra): ensure-config cache + Nova migration removal` (`7336958`)**
Hash-based fast-path cache (`.arness/<plugin>-ensure-config.local.json`) skips the 457-line ensure-config.md load when fingerprints match. Cross-platform shell (bash 3.2 compatible — works on Mac default bash, Linux, Git Bash on Windows). `.gitattributes` enforces LF on shell scripts for Windows checkouts. Also removes the obsolete Layer 0 Nova-to-Arness migration (171 lines across 3 files); historical changelog mentions and the Chevy Nova brand-naming case studies are intentionally kept.

## Version bumps

| Plugin | Before | After | Bumps |
|---|---|---|---|
| arn-code | 3.3.0 | **3.7.0** | 4 minor (one per feature) |
| arn-spark | 2.2.0 | **2.4.0** | 2 minor (features 1 + 4) |
| arn-infra | 2.2.0 | **2.4.0** | 2 minor (features 1 + 4) |

## Test plan

- [ ] All 11 cache-check.sh verification asserts pass (see commit 7336958 description)
- [ ] In a fresh consumer project with `balanced` profile, run `arn-code-plan` against a multi-phase spec → verify per-phase complexity surfaces, gate fires, override propagates to executor dispatch
- [ ] In the same project, run any entry-point skill twice → first writes the cache, second hits cache-valid status
- [ ] Edit CLAUDE.md `## Arness` block → next invocation sees cache miss (hash changed)
- [ ] Plugin upgrade → `pluginVersion` mismatch triggers cache miss
- [ ] On Mac default `/bin/bash` 3.2: cache-check.sh runs without `declare -A` errors (parallel indexed arrays)
- [ ] Run `arn-code-simplify` on `balanced` profile → review dispatches show `model: opus`, apply dispatch shows `model: sonnet`

## Notes on multi-touched files

A few files (`arn-code-plan/SKILL.md`, `arn-code-batch-planning/SKILL.md`, the 3 ensure-config.md files, the 23 entry-point Step 0 reads) were modified by multiple features. To keep per-commit diffs honest, each such file lands in the **latest** commit that touched it. The 4-commit history shows real per-feature deltas rather than reconstructed intermediate states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)